### PR TITLE
Fixes two bugs in the SeLion-Code-Generator

### DIFF
--- a/codegen/src/main/java/com/paypal/selion/plugins/CodeGeneratorMojo.java
+++ b/codegen/src/main/java/com/paypal/selion/plugins/CodeGeneratorMojo.java
@@ -50,6 +50,13 @@ public class CodeGeneratorMojo extends AbstractMojo {
      * @parameter expression="${selion-code-generator.basePackage}" default-value="com.paypal.selion.testcomponents"
      */
     private String basePackage;
+    
+    /**
+     * Represents the base folder used for reading yaml files.
+     * 
+     * @parameter expression="${selion-code-generator.baseFolder}" default-value="GUIData"
+     */
+    private String baseFolder;
 
     /**
      * List of "domains" to exclude during code generation.
@@ -102,8 +109,12 @@ public class CodeGeneratorMojo extends AbstractMojo {
 
     private String pathToFolder(File file) {
         String path = file.getAbsolutePath();
-        return path.substring(path.indexOf("GUIData") + "GUIData".length() + 1, path.lastIndexOf(File.separator))
+        try {
+            return path.substring(path.indexOf(baseFolder) + baseFolder.length() + 1, path.lastIndexOf(File.separator))
                 .trim();
+        } catch(StringIndexOutOfBoundsException ex) {
+            return "";
+        }
     }
 
     /*
@@ -121,7 +132,7 @@ public class CodeGeneratorMojo extends AbstractMojo {
 
         String sourceDir = sourceDir();
         String generatedSourceDir = generatedSourcesDir();
-        String resourceDir = resourcesDir();
+        String resourceDir = resourcesDir() + File.separator + baseFolder;
 
         List<File> allDataFiles = loadFiles(new File(resourceDir));
 
@@ -218,10 +229,10 @@ public class CodeGeneratorMojo extends AbstractMojo {
     }
 
     /**
-     * This method will return all the data files available in the GUIData dir and return List of {@link File}
+     * This method will return all the data files available in the base directory and return List of {@link File}
      * 
      * @param workingDir
-     *            - GUIData directory
+     *            - Base directory
      * @return List<File>
      */
     private List<File> loadFiles(File workingDir) {


### PR DESCRIPTION
Code generator went through all .yaml in scr/main/resources which will cause errors if user has .yaml files that are not compatible with the SeLion-Code-Generator. SeLion-Code-Generator will now stay in the GUIData folder as described by the documentation.

fixed: .yaml files in the GUIData root folder can now be parsed correctly
