### PR TITLE
Fix (issue #14) to display the paypal open source logo in IE browser

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,11 +18,11 @@
 <body>
 <div class="row selion-content-div">
   <div class="logo-background col-xs-12">
-    <p class="pull-right hidden-print
+    <p class="hidden-print
        hidden-xs" role="complementary"
        style="padding-top: 15px; padding-right: 25px;">
       <a href="http://paypal.github.io" title="PayPal Open Source">
-        <img src="images/paypalopensource.svg" width="175" border="0" alt="PayPal Open Source logo"/>
+        <img class="pull-right" src="images/paypalopensource.svg" width="175" border="0" alt="PayPal Open Source logo"/>
       </a>
     </p>
     <p style="padding: 20px;">&nbsp;</p>


### PR DESCRIPTION
Documentation home page is tested with multiple browser (IE, FireFox, Chrome and Safari)
