### PR TITLE
Added the code to specify the parameter to forceReinstall the Selendroid Server and AUT

### DIFF
--- a/client/src/main/java/com/paypal/selion/configuration/Config.java
+++ b/client/src/main/java/com/paypal/selion/configuration/Config.java
@@ -61,6 +61,8 @@ import com.paypal.selion.platform.grid.browsercapabilities.DefaultCapabilitiesBu
  * &lt;!-- optional, defaults to *firefox  --&gt;
  * &lt;parameter name="browser" value="*firefox" /&gt;
  * &lt;!-- optional, defaults to false  (GLOBAL) --&gt;
+ * &lt;parameter name="forceReinstall" value="" /&gt;
+ * &lt;!-- optional, defaults to false  (GLOBAL) --&gt;
  * &lt;parameter name="runLocally" value="true" /&gt;
  * &lt;!-- optional, turns automatic screen shots for click handlers on/off, defaults to true (GLOBAL) --&gt;
  * &lt;parameter name="autoScreenShot" value="true" /&gt;
@@ -586,7 +588,13 @@ public final class Config {
          * Device Serial to use.<br>
          * Default is selected automatically by Selendroid
          */
-        SELENDROID_DEVICE_SERIAL("selendroidDeviceSerial" , "", true);
+        SELENDROID_DEVICE_SERIAL("selendroidDeviceSerial" , "", true),
+        
+        /**
+         * Force Reinstall the Selendroid Server and AUT.<br>
+         * Default is selected automatically to false
+         */
+        SELENDROID_SERVER_FORCE_REINSTALL("forceReinstall" ,"false", true);
 
         private String name = null;
         private String defaultValue = null;

--- a/client/src/main/java/com/paypal/selion/platform/grid/LocalSelendroidNode.java
+++ b/client/src/main/java/com/paypal/selion/platform/grid/LocalSelendroidNode.java
@@ -189,6 +189,12 @@ public class LocalSelendroidNode implements LocalServerComponent {
         args.add(SelendroidSessionProxy.class.getCanonicalName());
         args.add("-host");
         args.add("127.0.0.1");
+        
+        Boolean selendroid_force_reinstall = Config.getBoolConfigProperty(ConfigProperty.SELENDROID_SERVER_FORCE_REINSTALL);
+        
+        if (selendroid_force_reinstall == true) {
+                  args.add("-forceReinstall");
+        }
 
         sconfig = SelendroidConfiguration.create(args.toArray(new String[args.size()]));
         server = new SelendroidLauncher(sconfig);

--- a/client/src/main/java/com/paypal/selion/platform/grid/LocalSelendroidNode.java
+++ b/client/src/main/java/com/paypal/selion/platform/grid/LocalSelendroidNode.java
@@ -190,9 +190,9 @@ public class LocalSelendroidNode implements LocalServerComponent {
         args.add("-host");
         args.add("127.0.0.1");
         
-        Boolean selendroid_force_reinstall = Config.getBoolConfigProperty(ConfigProperty.SELENDROID_SERVER_FORCE_REINSTALL);
+        Boolean selendroidForceReinstall = Config.getBoolConfigProperty(ConfigProperty.SELENDROID_SERVER_FORCE_REINSTALL);
         
-        if (selendroid_force_reinstall == true) {
+        if (selendroidForceReinstall == true) {
                   args.add("-forceReinstall");
         }
 


### PR DESCRIPTION
Usage: 

User can specify the forceReinstall parameter in the TestNG suite file as true to forceReinstall the Selendroid Server and AUT. This code helps for fresh reinstall of Selendroid Server ans AUT as sometimes there might resign issues with Selendroid Server and AUT not being resigned with same debug key and the test the might to start up.

Regards
Rajani
