### PR TITLE
Passing a config skipLoggingConfiguration flag to ios-driver to skip ios...

### DIFF
--- a/client/src/main/java/com/paypal/selion/platform/grid/LocalIOSNode.java
+++ b/client/src/main/java/com/paypal/selion/platform/grid/LocalIOSNode.java
@@ -177,6 +177,10 @@ class LocalIOSNode implements LocalServerComponent {
         Handler[] handlers = Logger.getLogger("").getHandlers();
         Level level = Logger.getLogger("").getLevel();
 
+        //add an option to skip ios default logger
+        args.add(" -skipLoggerConfiguration");
+        args.add(Boolean.TRUE.toString());
+
         IOSServerConfiguration config = IOSServerConfiguration.create(args.toArray(new String[args.size()]));
         server = new IOSServer(config);
         


### PR DESCRIPTION
...-driver logger configurations. See issue #30.
- This change should not be merged until https://github.com/ios-driver/ios-driver/issues/322 has been merged
