### PR TITLE
Replacing useragentUtils with uadetector library

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -190,8 +190,8 @@
 
         <!-- A utility for parsing user agent strings -->
         <dependency>
-            <groupId>nl.bitwalker</groupId>
-            <artifactId>UserAgentUtils</artifactId>
+                <groupId>net.sf.uadetector</groupId>
+                <artifactId>uadetector-resources</artifactId>
         </dependency>
 
         <!-- add xerces - used by runtime reporter -->

--- a/client/src/main/java/com/paypal/selion/platform/grid/ScreenShotRemoteWebDriver.java
+++ b/client/src/main/java/com/paypal/selion/platform/grid/ScreenShotRemoteWebDriver.java
@@ -22,8 +22,10 @@ import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.logging.Level;
 
-import nl.bitwalker.useragentutils.Browser;
-import nl.bitwalker.useragentutils.OperatingSystem;
+import net.sf.uadetector.OperatingSystem;
+import net.sf.uadetector.ReadableUserAgent;
+import net.sf.uadetector.UserAgentStringParser;
+import net.sf.uadetector.service.UADetectorServiceFactory;
 
 import org.apache.commons.lang.StringUtils;
 import org.openqa.selenium.Dimension;
@@ -121,12 +123,13 @@ public final class ScreenShotRemoteWebDriver extends EventFiringWebDriver {
     }
 
     private String extractBrowserInfo(String userAgent) {
-        Browser browser = Browser.parseUserAgentString(userAgent);
-        OperatingSystem os = OperatingSystem.parseUserAgentString(userAgent);
+        UserAgentStringParser parser = UADetectorServiceFactory.getResourceModuleParser();
+        ReadableUserAgent agent = parser.parse(userAgent);
+        OperatingSystem os = agent.getOperatingSystem();
         StringBuilder sb = new StringBuilder();
-        sb.append(browser.getName());
-        sb.append(" v:").append(browser.getVersion(userAgent));
-        sb.append(" running on ").append(os.getName());
+        sb.append(agent.getName());
+        sb.append(" v:").append(agent.getVersionNumber().toVersionString());
+        sb.append(" running on ").append(os.getName()).append(" v :").append(os.getVersionNumber().toVersionString());
         return sb.toString();
 
     }

--- a/client/src/test/java/com/paypal/selion/configuration/LocalConfigTest.java
+++ b/client/src/test/java/com/paypal/selion/configuration/LocalConfigTest.java
@@ -24,15 +24,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import nl.bitwalker.useragentutils.Browser;
+import net.sf.uadetector.ReadableUserAgent;
+import net.sf.uadetector.UserAgentStringParser;
+import net.sf.uadetector.service.UADetectorServiceFactory;
 
 import org.testng.ITestContext;
 import org.testng.annotations.Test;
 
 import com.paypal.selion.annotations.WebTest;
-import com.paypal.selion.configuration.Config;
-import com.paypal.selion.configuration.ConfigManager;
-import com.paypal.selion.configuration.LocalConfig;
 import com.paypal.selion.configuration.Config.ConfigProperty;
 import com.paypal.selion.platform.grid.Grid;
 
@@ -110,13 +109,20 @@ public class LocalConfigTest {
     public void testCorrectBrowserLaunched(ITestContext ctx) {
         Grid.driver().get("http://www.google.com");
         String userAgent = (String) Grid.driver().executeScript("return navigator.userAgent", "");
-        String actualBrowser = Browser.parseUserAgentString(userAgent).getName().toLowerCase();
+        UserAgentStringParser parser = UADetectorServiceFactory.getResourceModuleParser();
+        ReadableUserAgent agent = parser.parse(userAgent);
+        String actualBrowser = agent.getName().toLowerCase();
         // Read suite param directly.
         String browserParam = ctx.getCurrentXmlTest().getParameter("browser");
         // Ensure you've configured this test to run with browser param in suite file.
         assertTrue(!browserParam.isEmpty());
         // Drop the "* in browser and first char"
-        assertTrue(actualBrowser.contains(browserParam.substring(2).toLowerCase()));
+        if (browserParam.equals("*iexplore")) {
+            //Only for IE the user agent parsing library returns it as IE.
+            assertTrue(actualBrowser.equalsIgnoreCase("ie"));
+        }else {
+            assertTrue(actualBrowser.contains(browserParam.substring(1).toLowerCase()));
+        }
     }
 
     @Test(groups = "unit", expectedExceptions = { IllegalArgumentException.class })

--- a/project-bom/pom.xml
+++ b/project-bom/pom.xml
@@ -191,9 +191,9 @@
 
             <!-- A utility for parsing user agent strings -->
             <dependency>
-                <groupId>nl.bitwalker</groupId>
-                <artifactId>UserAgentUtils</artifactId>
-                <version>1.6</version>
+                <groupId>net.sf.uadetector</groupId>
+                <artifactId>uadetector-resources</artifactId>
+                <version>2014.04</version>
             </dependency>
 
             <!-- add xerces - used by runtime reporter -->


### PR DESCRIPTION
- UserAgentUtils library is NOT being published to
  Maven Central. This is preventing us from deploying
  to Maven Central. So switching from UserAgentUtils
  to UADetector library which also helps in parsing
  User Agents of browsers and is also available in 
  Maven central.
