### PR TITLE
Split app name and version in Capabilities

### DIFF
--- a/client/src/main/java/com/paypal/selion/annotations/MobileTest.java
+++ b/client/src/main/java/com/paypal/selion/annotations/MobileTest.java
@@ -44,6 +44,19 @@ public @interface MobileTest {
     String appName() default "";
 
     /**
+     * Establish the version of application to use. 
+     * The version can be specified as part of the appName as:
+     * Specify app version as part of the appName as:
+     * <pre>
+     * appName = &quot;Safari:7.0&quot;
+     * </pre>
+     * or by itself as:
+     * <pre>
+     * appVersion = &quot;7.0&quot;
+     */
+    String appVersion() default "";
+
+    /**
      * Establish the type of device to be used. Default's to <code>iphone</code>
      */
     String device() default "iphone";

--- a/client/src/main/java/com/paypal/selion/configuration/Config.java
+++ b/client/src/main/java/com/paypal/selion/configuration/Config.java
@@ -475,6 +475,19 @@ public final class Config {
         SELENIUM_NATIVE_APP_NAME("appName", "", false),
 
         /**
+         * This parameter represents the version of the app that is to be spawned. There are two way to specified the
+         * version of the native app.<br>
+         * Specify app version as part of the appName as:
+         * <pre>
+         * appName = &quot;Safari:7.0&quot;
+         * </pre>
+         * or by itself as:
+         * <pre>
+         * appVersion = &quot;7.0&quot;
+         */
+        SELENIUM_NATIVE_APP_VERSION("appVersion", "", false),
+
+        /**
          * This parameter represents the language to be used. By default it is always <code>English</code> represented
          * as <code>en</code>
          */

--- a/client/src/main/java/com/paypal/selion/platform/grid/MobileTestSession.java
+++ b/client/src/main/java/com/paypal/selion/platform/grid/MobileTestSession.java
@@ -34,6 +34,7 @@ import com.paypal.test.utilities.logging.SimpleLogger;
 public class MobileTestSession extends AbstractTestSession {
     private static SimpleLogger logger = SeLionLogger.getLogger();
     private String appName;
+    private String appVersion;
     private String appLocation;
     private String device = "iphone";
     private String appLanguage;
@@ -59,9 +60,17 @@ public class MobileTestSession extends AbstractTestSession {
         if (StringUtils.isBlank(appName)) {
             throw new IllegalArgumentException(
                     "Please specify the application name either via the @AppTest annotation or via the SeLion configuration parameter");
+        } else if (StringUtils.contains(appName, ":")) {
+            appVersion = StringUtils.split(this.appName, ":")[1];
+            appName = StringUtils.split(this.appName, ":")[0];
         }
         logger.exiting(appName);
         return appName;
+    }
+
+    public String getAppVersion() {
+        getAppName();
+        return appVersion;
     }
 
     public String getdeviceSerial() {
@@ -130,12 +139,19 @@ public class MobileTestSession extends AbstractTestSession {
         appLocale = getLocalConfigProperty(ConfigProperty.SELENIUM_NATIVE_APP_LOCALE);
         appLanguage = getLocalConfigProperty(ConfigProperty.SELENIUM_NATIVE_APP_LANGUAGE);
         appName = getLocalConfigProperty(ConfigProperty.SELENIUM_NATIVE_APP_NAME);
+        appVersion = getLocalConfigProperty(ConfigProperty.SELENIUM_NATIVE_APP_VERSION);
         deviceSerial = getLocalConfigProperty(ConfigProperty.SELENDROID_DEVICE_SERIAL);
 
         // Override values when supplied via the annotation
         if (deviceTestAnnotation != null) {
             if (StringUtils.isNotBlank(deviceTestAnnotation.appName())) {
                 this.appName = deviceTestAnnotation.appName();
+                if (StringUtils.contains(this.appName, ":")) {
+                    this.appVersion = StringUtils.split(this.appName, ":")[1];
+                }
+            }
+            if(StringUtils.isNotBlank(deviceTestAnnotation.appVersion())) {
+                this.appVersion = deviceTestAnnotation.appVersion();
             }
             if (StringUtils.isNotBlank(deviceTestAnnotation.language())) {
                 this.appLanguage = deviceTestAnnotation.language();

--- a/client/src/main/java/com/paypal/selion/platform/grid/browsercapabilities/GenericCapabilitiesBuilder.java
+++ b/client/src/main/java/com/paypal/selion/platform/grid/browsercapabilities/GenericCapabilitiesBuilder.java
@@ -25,6 +25,7 @@ import com.paypal.selion.platform.grid.MobileTestSession;
 
 class GenericCapabilitiesBuilder extends DefaultCapabilitiesBuilder {
     private String appName = null;
+    private String appVersion = null;
     private String deviceType = null;
     private String language = null;
     private String locale = null;
@@ -47,6 +48,7 @@ class GenericCapabilitiesBuilder extends DefaultCapabilitiesBuilder {
             caps = SelendroidCapabilities.android();
             caps.setBrowserName("selendroid");
             caps.setCapability(SelendroidCapabilities.AUT, appName);
+            caps.setCapability(SelendroidCapabilities.AUT_VERSION, appVersion);
             String platformVersion = deviceType.toLowerCase().replace("android", "");
             caps.setCapability(SelendroidCapabilities.PLATFORM_VERSION, platformVersion);
             caps.setCapability(SelendroidCapabilities.LOCALE, this.locale);
@@ -60,6 +62,7 @@ class GenericCapabilitiesBuilder extends DefaultCapabilitiesBuilder {
     private void initCapabilities() {
         MobileTestSession config = Grid.getMobileTestSession();
         if (config != null) {
+            this.appVersion = config.getAppVersion();
             this.appName = config.getAppName();
             this.deviceType = config.getDevice();
             this.language = config.getAppLanguage();


### PR DESCRIPTION
To enhance capability matching and select the latest version of the app to test if the
app version is not provided by the users.

Signed-off-by: Binh Vu bvu@paypal.com
