### PR TITLE
Add functionality for a user to hover an element.

### DIFF
--- a/client/src/main/java/com/paypal/selion/platform/html/AbstractElement.java
+++ b/client/src/main/java/com/paypal/selion/platform/html/AbstractElement.java
@@ -31,6 +31,7 @@ import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.remote.RemoteWebElement;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.WebDriverWait;
@@ -47,6 +48,7 @@ import com.paypal.selion.platform.html.support.HtmlElementUtils;
 import com.paypal.selion.platform.html.support.ParentNotFoundException;
 import com.paypal.selion.platform.html.support.events.Clickable;
 import com.paypal.selion.platform.html.support.events.ElementEventListener;
+import com.paypal.selion.platform.html.support.events.Hoverable;
 import com.paypal.selion.platform.utilities.WebDriverWaitUtils;
 import com.paypal.selion.reports.runtime.WebReporter;
 import com.paypal.selion.testcomponents.BasicPageImpl;
@@ -55,7 +57,7 @@ import com.paypal.test.utilities.logging.SimpleLogger;
 /**
  * Abstract element class for web elements.
  */
-public abstract class AbstractElement implements Clickable {
+public abstract class AbstractElement implements Clickable, Hoverable {
     private static final String ALERTS_ARE_NOT_SUPPORTED_ERR_MSG = "Alerts are not supported in iPhone/iPad/PhantomJS as of 2.39.0.";
     private String locator;
     private String controlName;
@@ -676,6 +678,36 @@ public abstract class AbstractElement implements Clickable {
             processScreenShot();
             
             dispatcher.afterClick(this, expected);
+        }
+    }
+    
+    /**
+     * Moves the mouse pointer to the middle of the element. And waits for the expected elements to be visible.
+     * 
+     * @param expected
+     *            - parameters in the form of an element locator {@link String}, a
+     *            {@link Button}, a {@link TextField}, an {@link Image}, a {@link Form}, a {@link Label}, a
+     *            {@link Table}, a {@link SelectList}, a {@link CheckBox}, or a {@link RadioButton}.
+     */
+    public void hover(final Object... expected) {
+        dispatcher.beforeHover(this, expected);
+        
+        new Actions(Grid.driver()).moveToElement(getElement()).perform();
+        
+        try {
+            for (Object expect : expected) {
+                if (expect instanceof AbstractElement) {
+                    AbstractElement a = (AbstractElement) expect;
+                    WebDriverWaitUtils.waitUntilElementIsVisible(a.getLocator());
+                } else if (expect instanceof String) {
+                    String s = (String) expect;
+                    WebDriverWaitUtils.waitUntilElementIsVisible(s);
+                }
+            }
+        } finally {
+            processScreenShot();
+            
+            dispatcher.afterHover(this, expected);
         }
     }
 }

--- a/client/src/main/java/com/paypal/selion/platform/html/support/events/AbstractElementEventListener.java
+++ b/client/src/main/java/com/paypal/selion/platform/html/support/events/AbstractElementEventListener.java
@@ -141,4 +141,13 @@ public abstract class AbstractElementEventListener implements ElementEventListen
         //NOSONAR
     }
 
+    @Override
+    public void beforeHover(Hoverable target, Object... expected) {
+        //NOSONAR
+    }
+
+    @Override
+    public void afterHover(Hoverable target, Object... expected) {
+        //NOSONAR
+    }
 }

--- a/client/src/main/java/com/paypal/selion/platform/html/support/events/ElementEventListener.java
+++ b/client/src/main/java/com/paypal/selion/platform/html/support/events/ElementEventListener.java
@@ -243,4 +243,24 @@ public interface ElementEventListener {
      * @param target Instance of the element that triggered this event and implements {@link Selectable}
      */
     void afterDeselect(Deselectable target);
+    
+    /**
+     * This event gets triggered before we hover an element. The following objects trigger this event,
+     * {@link Button}, {@link CheckBox}, {@link DatePicker}, {@link Form}, {@link Image}, {@link Label}, {@link Link},
+     * {@link RadioButton}, {@link SelectList}, {@link Table}, {@link TextField}
+     * 
+     * @param target Instance of the element that triggered this event and implements {@link Hoverable}
+     * @param expected The expected objects that were passed to the hover method
+     */
+    void beforeHover(Hoverable target, Object... expected);
+    
+    /**
+     * This event gets triggered after we hover an element. The following objects trigger this event,
+     * {@link Button}, {@link CheckBox}, {@link DatePicker}, {@link Form}, {@link Image}, {@link Label}, {@link Link},
+     * {@link RadioButton}, {@link SelectList}, {@link Table}, {@link TextField}
+     * 
+     * @param target Instance of the element that triggered this event and implements {@link Hoverable}
+     * @param expected The expected objects that were passed to the hover method
+     */
+    void afterHover(Hoverable target, Object... expected);
 }

--- a/client/src/main/java/com/paypal/selion/platform/html/support/events/Hoverable.java
+++ b/client/src/main/java/com/paypal/selion/platform/html/support/events/Hoverable.java
@@ -1,0 +1,5 @@
+package com.paypal.selion.platform.html.support.events;
+
+public interface Hoverable {
+
+}

--- a/client/src/test/java/com/paypal/selion/platform/html/support/events/ElementEventTest.java
+++ b/client/src/test/java/com/paypal/selion/platform/html/support/events/ElementEventTest.java
@@ -49,6 +49,24 @@ public class ElementEventTest {
     
     @Test(groups = { "functional" })
     @WebTest
+    public void testHoverEvents() throws InterruptedException, IOException {
+        Grid.open("about:blank");
+        RemoteWebDriver driver = (RemoteWebDriver) Grid.driver().getWrappedDriver();
+        String script = getScript();
+        driver.executeScript(script);
+        Thread.sleep(4000);
+        
+        Grid.driver().register(new ElementListenerTestImpl());
+
+        TestPage page = new TestPage("US");
+
+        page.getContinueButton().hover();
+        Assert.assertEquals(page.getLogLabel().getProperty("data-before-hover"), "true", "beforeHover method was not triggered.");
+        Assert.assertEquals(page.getLogLabel().getProperty("data-after-hover"), "true", "afterHover method was not triggered.");
+    }
+    
+    @Test(groups = { "functional" })
+    @WebTest
     public void testTypeEvents() throws InterruptedException, IOException {
         Grid.open("about:blank");
         RemoteWebDriver driver = (RemoteWebDriver) Grid.driver().getWrappedDriver();

--- a/client/src/test/java/com/paypal/selion/platform/html/support/events/ElementListenerTestImpl.java
+++ b/client/src/test/java/com/paypal/selion/platform/html/support/events/ElementListenerTestImpl.java
@@ -213,4 +213,20 @@ public class ElementListenerTestImpl implements ElementEventListener {
         page.getLogLabel().setProperty("data-after-deselect", "true");
     }
 
+    @Override
+    public void beforeHover(Hoverable target, Object... expected) {
+        AbstractElement element = (AbstractElement) target;
+        TestPage page = (TestPage) element.getParent().getCurrentPage();
+        
+        page.getLogLabel().setProperty("data-before-hover", "true");
+    }
+
+    @Override
+    public void afterHover(Hoverable target, Object... expected) {
+        AbstractElement element = (AbstractElement) target;
+        TestPage page = (TestPage) element.getParent().getCurrentPage();
+        
+        page.getLogLabel().setProperty("data-after-hover", "true");
+    }
+
 }


### PR DESCRIPTION
Adds functionality for a user to hover an element. The user can also provide expected objects that should be visible after hovering the element.

An screenshot gets automatically take once we hovered to the element. We also trigger events just like other actions we perform on elements.

The hover method should be useful for handling websites with dropdown menus.
