### PR TITLE
Fixes issue where if we call isElementPresent and there are no page titles defined it will throw an NullPointException

### DIFF
--- a/client/src/main/java/com/paypal/selion/platform/html/AbstractElement.java
+++ b/client/src/main/java/com/paypal/selion/platform/html/AbstractElement.java
@@ -50,6 +50,7 @@ import com.paypal.selion.platform.html.support.events.ElementEventListener;
 import com.paypal.selion.platform.utilities.WebDriverWaitUtils;
 import com.paypal.selion.reports.runtime.WebReporter;
 import com.paypal.selion.testcomponents.BasicPageImpl;
+import com.paypal.selion.testcomponents.PageYamlException;
 import com.paypal.test.utilities.logging.SimpleLogger;
 
 /**
@@ -145,7 +146,13 @@ public abstract class AbstractElement implements Clickable {
         // Find if page exists: This part is reached after a valid page instance is assigned to page variable. So its
         // safe to proceed!
 
-        boolean pageExists = page.hasExpectedPageTitle();
+        boolean pageExists = false;
+        
+        try {
+            pageExists = page.hasExpectedPageTitle();
+        } catch(PageYamlException ex) {
+            //NOSONAR
+        }
 
         if (!pageExists) {
             // ParentType: Page does not exist: Sending the cause along with it

--- a/client/src/main/java/com/paypal/selion/testcomponents/BasicPageImpl.java
+++ b/client/src/main/java/com/paypal/selion/testcomponents/BasicPageImpl.java
@@ -115,7 +115,11 @@ public abstract class BasicPageImpl extends AbstractPage implements ParentTraits
      *         returns false
      */
     public boolean hasExpectedPageTitle() {
-
+        // If there are no page titles defined we should return false
+        if(getPage().pageTitle == null) {
+            throw new PageYamlException(getPage().getClass().getName() + ".yaml has no pageTitle defined.");
+        }
+        
         List<String> pageTitles = Arrays.asList(getPage().pageTitle.split("\\|"));
         for (String title : pageTitles) {
             if (RegexUtils.wildCardMatch(getPage().getActualPageTitle(), title)) {

--- a/client/src/main/java/com/paypal/selion/testcomponents/PageYamlException.java
+++ b/client/src/main/java/com/paypal/selion/testcomponents/PageYamlException.java
@@ -1,0 +1,32 @@
+/*-------------------------------------------------------------------------------------------------------------------*\
+|  Copyright (C) 2014 eBay Software Foundation                                                                        |
+|                                                                                                                     |
+|  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
+|  with the License.                                                                                                  |
+|                                                                                                                     |
+|  You may obtain a copy of the License at                                                                            |
+|                                                                                                                     |
+|       http://www.apache.org/licenses/LICENSE-2.0                                                                    |
+|                                                                                                                     |
+|  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed   |
+|  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for  |
+|  the specific language governing permissions and limitations under the License.                                     |
+\*-------------------------------------------------------------------------------------------------------------------*/
+
+/**
+ * This exception is intended to encompass all exceptions that might be thrown when we interact with PageYaml files.
+ */
+package com.paypal.selion.testcomponents;
+
+public class PageYamlException extends RuntimeException {
+
+    /**
+     * the generated serial version ID.
+     */
+    private static final long serialVersionUID = 8843474074395460717L;
+
+    public PageYamlException(String msg) {
+        super(msg);
+    }
+
+}


### PR DESCRIPTION
This PR address an issue that if we call isElementPresent on a element of which the page yaml has no pageTitle defined it will throw an Exception.

Issue comes from the following line of code the method add extra info when a element can't be located. But on the following line [AbstractElement.java#L148](https://github.com/paypal/SeLion/blob/develop/client/src/main/java/com/paypal/selion/platform/html/AbstractElement.java#L148). we verify if the elements parentPage is loaded based on pageTitle. Is that something that we should be doing? Isn't it up to the user to ensure that they are on the correct page?
