### PR TITLE
Adding capability to specify sdk version / device variation via Webtest ...

### DIFF
--- a/client/src/main/java/com/paypal/selion/annotations/MobileTest.java
+++ b/client/src/main/java/com/paypal/selion/annotations/MobileTest.java
@@ -69,12 +69,12 @@ public @interface MobileTest {
     String locale() default "en_US";
 
     /**
-     * Device Serial to be used. Defaults to device/emulator chosen by Selendroid
+     * Device Serial to be used. Defaults to device/emulator chosen by Selendroid / iosDriver
      */
     String deviceSerial() default "";
 
     /**
-     * Establish the type of device to be used (Nexus5, iPhone6, iPadAir, etc).
+     * Establish the type of device to be used (Nexus5, Iphone5s, etc).
      * Defaults to device/emulator chosen by Selendroid / iosDriver
      */
     String deviceType() default "";

--- a/client/src/main/java/com/paypal/selion/internal/grid/capabilities/SeLionCapabilitiesMatcher.java
+++ b/client/src/main/java/com/paypal/selion/internal/grid/capabilities/SeLionCapabilitiesMatcher.java
@@ -15,7 +15,7 @@
 
 package com.paypal.selion.internal.grid.capabilities;
 
-import io.selendroid.SelendroidCapabilities;
+import io.selendroid.common.SelendroidCapabilities;
 import io.selendroid.grid.SelendroidCapabilityMatcher;
 
 import java.util.HashMap;

--- a/client/src/main/java/com/paypal/selion/platform/grid/Grid.java
+++ b/client/src/main/java/com/paypal/selion/platform/grid/Grid.java
@@ -15,8 +15,6 @@
 
 package com.paypal.selion.platform.grid;
 
-import io.selendroid.SelendroidDriver;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -30,12 +28,17 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicHttpEntityEnclosingRequest;
+
 import org.json.JSONException;
 import org.json.JSONObject;
+
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.remote.SessionId;
+
 import org.uiautomation.ios.client.uiamodels.impl.RemoteIOSDriver;
 import org.uiautomation.ios.client.uiamodels.impl.augmenter.IOSDriverAugmenter;
+
+import io.selendroid.client.SelendroidDriver;
 
 import com.paypal.selion.annotations.MobileTest;
 import com.paypal.selion.annotations.WebTest;

--- a/client/src/main/java/com/paypal/selion/platform/grid/LocalSelendroidNode.java
+++ b/client/src/main/java/com/paypal/selion/platform/grid/LocalSelendroidNode.java
@@ -19,17 +19,13 @@ import io.selendroid.grid.SelendroidSessionProxy;
 import io.selendroid.standalone.SelendroidConfiguration;
 import io.selendroid.standalone.SelendroidLauncher;
 
-import java.io.File;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.apache.commons.configuration.ConversionException;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.filefilter.FileFilterUtils;
 import org.openqa.grid.common.exception.GridException;
 
 import com.paypal.selion.configuration.Config;
@@ -103,41 +99,22 @@ class LocalSelendroidNode extends AbstractNode implements LocalServerComponent {
         args.add("-selendroidServerPort");
         args.add(Integer.toString(Config.getIntConfigProperty(ConfigProperty.SELENDROID_SERVER_PORT)));
 
+        // Specify the aut folder so its contents will be monitored and read by Selendroid.
         String autFolder = Config.getConfigProperty(ConfigProperty.SELENIUM_NATIVE_APP_FOLDER);
         if ((autFolder != null) && (!autFolder.trim().isEmpty())) {
-            File folder = new File(autFolder);
-            try {
-                Collection<File> files = FileUtils.listFiles(folder,
-                    FileFilterUtils.and(FileFilterUtils
-                               .notFileFilter(FileFilterUtils
-                                        .prefixFileFilter("resigned")),
-                        FileFilterUtils.suffixFileFilter(".apk")),
-                        FileFilterUtils.notFileFilter(FileFilterUtils
-                                .directoryFileFilter()));
-
-                for (File file : files) {
-                    args.add("-aut");
-                    args.add(file.getAbsolutePath());
-                }
-            } catch (IllegalArgumentException iae) {
-                logger.warning(iae.getMessage());
-            }
+            args.add("-folder");
+            args.add(autFolder);
         }
 
         String timeoutEmulatorStart = checkAndValidateParameters(ConfigProperty.SELENDROID_EMULATOR_START_TIMEOUT);
         args.add(" -timeoutEmulatorStart ");
         args.add(timeoutEmulatorStart);
-        //TODO: krmahadevan says :
-        //This configuration is NOT yet available in Selendroid 0.11.0. So I am commenting out using it right now.
-        //We anyways are going to be moving over to the newer version of Selendroid very soon. So this can be enabled back
-        //once we depend on the newer version of Selendroid.
-//        String serverStartTimeout = checkAndValidateParameters(ConfigProperty.SELENDROID_SERVER_START_TIMEOUT);
-//        args.add(" -serverStartTimeout ");
-//        args.add(serverStartTimeout);
+        String serverStartTimeout = checkAndValidateParameters(ConfigProperty.SELENDROID_SERVER_START_TIMEOUT);
+        args.add(" -serverStartTimeout ");
+        args.add(serverStartTimeout);
         String sessionTimeout = checkAndValidateParameters(ConfigProperty.MOBILE_DRIVER_SESSION_TIMEOUT);
         args.add(" -sessionTimeout ");
         args.add(sessionTimeout);
-        
         args.add("-proxy");
         args.add(SelendroidSessionProxy.class.getCanonicalName());
         args.add("-host");
@@ -217,5 +194,4 @@ class LocalSelendroidNode extends AbstractNode implements LocalServerComponent {
         logger.exiting(validatedValue);
         return validatedValue;
     }
-
 }

--- a/client/src/main/java/com/paypal/selion/platform/grid/LocalSelendroidNode.java
+++ b/client/src/main/java/com/paypal/selion/platform/grid/LocalSelendroidNode.java
@@ -15,9 +15,9 @@
 
 package com.paypal.selion.platform.grid;
 
-import io.selendroid.SelendroidConfiguration;
-import io.selendroid.SelendroidLauncher;
 import io.selendroid.grid.SelendroidSessionProxy;
+import io.selendroid.standalone.SelendroidConfiguration;
+import io.selendroid.standalone.SelendroidLauncher;
 
 import java.io.File;
 import java.util.ArrayList;

--- a/client/src/main/java/com/paypal/selion/platform/grid/MobileTestSession.java
+++ b/client/src/main/java/com/paypal/selion/platform/grid/MobileTestSession.java
@@ -76,7 +76,7 @@ public class MobileTestSession extends AbstractTestSession {
 
     public WebDriverPlatform getPlatform() {
         WebDriverPlatform platform = WebDriverPlatform.ANDROID;
-        if (getDevice().toLowerCase().contains("iphone") || getDevice().toLowerCase().contains("ipad")) {
+        if (getDevice().equalsIgnoreCase("iphone") || getDevice().equalsIgnoreCase("ipad")) {
             platform = WebDriverPlatform.IOS;
         }
         return platform;
@@ -87,22 +87,15 @@ public class MobileTestSession extends AbstractTestSession {
     }
 
     public String getDevice() {
-        final String errorMessage = "The device should either be provided as 'iphone', 'ipad', 'iphone:7.1', 'android',"
-                            + " 'android:17', 'android:18', etc.";
-        if (StringUtils.isNotBlank(device) &&
-                (device.toLowerCase().contains("android") || device.toLowerCase().contains("iphone") || device.toLowerCase().contains("ipad"))) {
-            if (device.contains(":")) {
-                String args[] = device.split(":");
-                //validate to make sure we only get 2 parameters
-                if (args == null || args.length !=2) {
-                    throw new IllegalArgumentException(errorMessage);
-                }
-                platformVersion = args[1];
-                device = args[0];
+        if (device.contains("android") || device.contains("iphone") || device.contains("ipad")) {
+            if (StringUtils.contains(device, ":")) {
+                platformVersion = StringUtils.split(this.device, ":")[1];
+                device = StringUtils.split(this.device, ":")[0];
             }
             return device;
         } else {
-            throw new IllegalArgumentException(errorMessage);
+            throw new IllegalArgumentException("The device should either be provided as 'iphone', 'ipad', 'iphone:7.1', 'android',"
+                    + " 'android:17', 'android:18', etc.");
         }
     }
 
@@ -113,7 +106,7 @@ public class MobileTestSession extends AbstractTestSession {
     @Override
     public SeLionSession startSesion() {
         logger.entering();
-        BrowserFlavors flavor;
+        BrowserFlavors flavor = null;
         try {
             flavor = BrowserFlavors.getBrowser(this.appName);
         } catch (IllegalArgumentException ex) {

--- a/client/src/main/java/com/paypal/selion/platform/grid/browsercapabilities/GenericCapabilitiesBuilder.java
+++ b/client/src/main/java/com/paypal/selion/platform/grid/browsercapabilities/GenericCapabilitiesBuilder.java
@@ -15,7 +15,7 @@
 
 package com.paypal.selion.platform.grid.browsercapabilities;
 
-import io.selendroid.SelendroidCapabilities;
+import io.selendroid.common.SelendroidCapabilities;
 
 import org.apache.commons.lang.StringUtils;
 import org.openqa.selenium.remote.DesiredCapabilities;

--- a/client/src/main/java/com/paypal/selion/platform/grid/browsercapabilities/GenericCapabilitiesBuilder.java
+++ b/client/src/main/java/com/paypal/selion/platform/grid/browsercapabilities/GenericCapabilitiesBuilder.java
@@ -42,20 +42,17 @@ class GenericCapabilitiesBuilder extends DefaultCapabilitiesBuilder {
         initCapabilities();
         DesiredCapabilities caps = null;
 
-        if (this.device.toLowerCase().contains("ipad") || this.device.toLowerCase().contains("iphone")) {
+        if (StringUtils.isNotBlank(device) && StringUtils.contains(this.device, ":")) {
+          this.platformVersion = StringUtils.split(this.device, ":")[1];
+        }
+
+        if (this.device.contains("ipad") || this.device.contains("iphone")) {
             caps = new IOSCapabilities();
 
             String appVersion = null;
             if (StringUtils.isNotBlank(appName) && StringUtils.contains(this.appName, ":")) {
-                String[] args = StringUtils.split(this.appName,":");
-                //check to make sure only we only get 2 params
-                if (args == null || args.length != 2) {
-                    throw new IllegalArgumentException("The appName should either be provided as 'app:version'. " +
-                            "Ex 'Safari:7.0', 'ebay:2.0'.");
-                }
-
-                appVersion = args[1];
-                appName = args[0];
+                appVersion = StringUtils.split(this.appName, ":")[1];
+                appName = StringUtils.split(this.appName, ":")[0];
             }
 
             caps.setCapability(IOSCapabilities.DEVICE, device);
@@ -75,8 +72,13 @@ class GenericCapabilitiesBuilder extends DefaultCapabilitiesBuilder {
             caps = SelendroidCapabilities.android();
             caps.setBrowserName("selendroid");
             caps.setCapability(SelendroidCapabilities.AUT, appName);
-            caps.setCapability(SelendroidCapabilities.PLATFORM_VERSION, platformVersion);
             caps.setCapability(SelendroidCapabilities.LOCALE, this.locale);
+            if(this.deviceType != null && !this.deviceType.isEmpty()) {
+              caps.setCapability(SelendroidCapabilities.MODEL, deviceType);
+            }
+            if(this.platformVersion != null && !this.platformVersion.isEmpty()) {
+              caps.setCapability(SelendroidCapabilities.PLATFORM_VERSION, platformVersion);
+            }
             if(!this.deviceSerial.isEmpty()) {
                 caps.setCapability(SelendroidCapabilities.SERIAL, this.deviceSerial);
             }

--- a/client/src/main/java/com/paypal/selion/platform/remote/SeLionDriverAugmenter.java
+++ b/client/src/main/java/com/paypal/selion/platform/remote/SeLionDriverAugmenter.java
@@ -19,8 +19,8 @@ import org.openqa.selenium.remote.HttpCommandExecutor;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.WebDriverException;
 
-import io.selendroid.SelendroidDriver;
-import io.selendroid.SelendroidCapabilities;
+import io.selendroid.client.SelendroidDriver;
+import io.selendroid.common.SelendroidCapabilities;
 
 import org.openqa.selenium.Beta;
 

--- a/client/src/main/java/com/paypal/selion/platform/remote/SeLionRemoteSelendroidDriver.java
+++ b/client/src/main/java/com/paypal/selion/platform/remote/SeLionRemoteSelendroidDriver.java
@@ -15,8 +15,8 @@
 
 package com.paypal.selion.platform.remote;
 
-import io.selendroid.SelendroidDriver;
-import io.selendroid.SelendroidCapabilities;
+import io.selendroid.client.SelendroidDriver;
+import io.selendroid.common.SelendroidCapabilities;
 
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.remote.HttpCommandExecutor;

--- a/client/src/test/java/com/paypal/selion/ios/sample/NativeAppDemo.java
+++ b/client/src/test/java/com/paypal/selion/ios/sample/NativeAppDemo.java
@@ -15,15 +15,11 @@
 
 package com.paypal.selion.ios.sample;
 
-import java.net.URL;
 import java.util.List;
 
-import com.paypal.selion.configuration.Config;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.paypal.selion.annotations.MobileTest;
@@ -32,16 +28,7 @@ import com.paypal.selion.reports.runtime.MobileReporter;
 
 public class NativeAppDemo {
 
-    private static final String appFolder = "/apps";
-
-    @BeforeClass
-    public void setup() {
-        URL url = NativeAppDemo.class.getResource(appFolder);
-        Config.setConfigProperty(Config.ConfigProperty.SELENIUM_NATIVE_APP_FOLDER, url.getPath());
-    }
-
-
-    @MobileTest(appName = "InternationalMountains", device = "iphone:7.1", deviceType = "iPhone4s")
+    @MobileTest(appName = "InternationalMountains", device = "iphone7.1", deviceSerial = "iPhone4s")
     @Test
     public void testSDKDeviceVariation4s() throws InterruptedException {
         MobileReporter.log("My Screenshot 1", true);
@@ -125,10 +112,17 @@ public class NativeAppDemo {
         System.out.println(text.getAttribute("name"));
     }
 
-    @AfterClass
-    public void teardown() {
-        Config.setConfigProperty(Config.ConfigProperty.SELENIUM_NATIVE_APP_FOLDER,
-                Config.ConfigProperty.SELENIUM_NATIVE_APP_FOLDER.getDefaultValue());
+    @MobileTest(appName = "Safari", device = "ipad")
+    @Test
+    public void testIOSDefaultsIpad() throws InterruptedException {
+        MobileReporter.log("My Screenshot 1", true);
+        Grid.open("http://www.paypal.com");
     }
 
+    @MobileTest(appName = "Safari", device = "ipad:8.0", deviceType = "iPadAir")
+    @Test
+    public void testIOSDefaultsIpadAir() throws InterruptedException {
+        MobileReporter.log("My Screenshot 1", true);
+        Grid.open("http://www.paypal.com");
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <selenium.version>2.44.0</selenium.version>
         <iosdriver.version>0.6.6-SNAPSHOT</iosdriver.version>
-        <selendroid.version>0.13.0-SNAPSHOT</selendroid.version>
+        <selendroid.version>0.13.0</selendroid.version>
         <testng.version>6.8.7</testng.version>
         <project.bom.version>${project.version}</project.bom.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <selenium.version>2.44.0</selenium.version>
         <iosdriver.version>0.6.6-SNAPSHOT</iosdriver.version>
-        <selendroid.version>0.11.0</selendroid.version>
+        <selendroid.version>0.13.0-SNAPSHOT</selendroid.version>
         <testng.version>6.8.7</testng.version>
         <project.bom.version>${project.version}</project.bom.version>
     </properties>

--- a/server/src/main/java/com/paypal/selion/grid/internal/SeLionCapabilitiesMatcher.java
+++ b/server/src/main/java/com/paypal/selion/grid/internal/SeLionCapabilitiesMatcher.java
@@ -15,7 +15,7 @@
 
 package com.paypal.selion.grid.internal;
 
-import io.selendroid.SelendroidCapabilities;
+import io.selendroid.common.SelendroidCapabilities;
 import io.selendroid.grid.SelendroidCapabilityMatcher;
 
 import java.util.HashMap;


### PR DESCRIPTION
...annotations. #57

Providing a way to pick a specific device to test when there are
more than one devices with the same SDK version.

For IOS this can be iPhone 5/5S, iPhone 6/Plus...
For android this can be Nexus 4, Galaxy 3S...

Signed-off-by: Binh Vu bvu@paypal.com
