### PR TITLE
Disable doclint for javadoc generation on Java8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.9.1</version>
+                    <version>2.10.1</version>
                     <configuration>
                         <minmemory>128m</minmemory>
                         <maxmemory>512</maxmemory>
@@ -190,6 +190,7 @@
                         <links>
                             <link>http://docs.oracle.com/javase/7/docs/api/</link>
                         </links>
+                        <additionalparam>-Xdoclint:none</additionalparam>
                     </configuration>
                     <executions>
                         <execution>
@@ -273,7 +274,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
+                <version>2.10.1</version>
                 <configuration>
                     <minmemory>128m</minmemory>
                     <maxmemory>512</maxmemory>


### PR DESCRIPTION
This fixes the build on Java8 until we can pay more attention to the doclint ERRORS produced and address them all.
