### PR TITLE
Add support for specifying additional DesiredCapabilities for Mobile Tests

### DIFF
--- a/client/src/main/java/com/paypal/selion/annotations/MobileTest.java
+++ b/client/src/main/java/com/paypal/selion/annotations/MobileTest.java
@@ -79,4 +79,17 @@ public @interface MobileTest {
      */
     String deviceType() default "";
 
+    /**
+     * Provide additional capabilities that you may wish to add as a name value pair. Values of true or false will be
+     * treated as Boolean capabilities unless you surround the value with '
+     * 
+     * <pre>
+     * {@literal @}Test
+     * {@literal @}MobileTest(additionalCapabilities={"key1:value1","key2:value2"})
+     * public void testMethod(){
+     *     // flow
+     * }
+     * </pre>
+     */
+    String[] additionalCapabilities() default {};
 }

--- a/client/src/main/java/com/paypal/selion/annotations/WebTest.java
+++ b/client/src/main/java/com/paypal/selion/annotations/WebTest.java
@@ -94,7 +94,8 @@ public @interface WebTest {
     String sessionName() default "";
 
     /**
-     * Provide additional capabilities that you may wish to add as a name value pair.
+     * Provide additional capabilities that you may wish to add as a name value pair. Values of true or false will be
+     * treated as Boolean capabilities unless you surround the value with '
      * 
      * <pre>
      * {@literal @}Test

--- a/client/src/main/java/com/paypal/selion/platform/grid/AbstractTestSession.java
+++ b/client/src/main/java/com/paypal/selion/platform/grid/AbstractTestSession.java
@@ -21,11 +21,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang.StringUtils;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 import com.paypal.selion.annotations.MobileTest;
 import com.paypal.selion.annotations.WebTest;
 import com.paypal.selion.configuration.ConfigManager;
+import com.paypal.selion.configuration.ExtendedConfig;
 import com.paypal.selion.configuration.Config.ConfigProperty;
 import com.paypal.selion.internal.grid.SauceLabsHelper;
 import com.paypal.selion.internal.utils.InvokedMethodInformation;
@@ -95,12 +97,36 @@ public abstract class AbstractTestSession {
 
     }
 
-    protected final Map<String, String> parseIntoCapabilities(String[] capabilities) {
-        Map<String, String> capabilityMap = new HashMap<String, String>();
+    protected void initializeAdditionalCapabilities(String[] additionalCapabilities, InvokedMethodInformation method) {
+        Object additionalCaps = method.getTestAttribute(ExtendedConfig.CAPABILITIES.getConfig());
+        if (additionalCaps instanceof DesiredCapabilities) {
+            this.additionalCapabilities.merge((DesiredCapabilities) additionalCaps);
+        }
+        if (additionalCapabilities.length != 0) {
+            Map<String, Object> capabilityMap = parseIntoCapabilities(additionalCapabilities);
+            // We found some capabilities. Lets merge them.
+            this.additionalCapabilities.merge(new DesiredCapabilities(capabilityMap));
+        }
+    }
+
+    protected final Map<String, Object> parseIntoCapabilities(String[] capabilities) {
+        Map<String, Object> capabilityMap = new HashMap<String, Object>();
         for (String eachCapability : capabilities) {
-            String[] keyValuePair = eachCapability.split(":");
+            String[] keyValuePair = eachCapability.split(":", 2);
             if (keyValuePair.length == 2) {
-                capabilityMap.put(keyValuePair[0], keyValuePair[1]);
+                String value = keyValuePair[1];
+                Object desiredCapability = value;
+                if (value.startsWith("'") && value.endsWith("'")) {
+                    String trimmedValue = StringUtils.mid(value, 1, value.length() - 2);
+                    if (trimmedValue.equalsIgnoreCase("true")) {
+                        desiredCapability = "true";
+                    } else if (trimmedValue.equalsIgnoreCase("false")) {
+                        desiredCapability = "false";
+                    }
+                } else if (value.equalsIgnoreCase("true") || value.equalsIgnoreCase("false")) {
+                    desiredCapability = Boolean.parseBoolean(value);
+                }
+                capabilityMap.put(keyValuePair[0], desiredCapability);
             } else {
                 StringBuffer errMsg = new StringBuffer();
                 errMsg.append("Capabilities are to be provided as name value pair separated by colons. ");

--- a/client/src/main/java/com/paypal/selion/platform/grid/MobileTestSession.java
+++ b/client/src/main/java/com/paypal/selion/platform/grid/MobileTestSession.java
@@ -18,9 +18,11 @@ package com.paypal.selion.platform.grid;
 import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
+import org.openqa.selenium.remote.DesiredCapabilities;
 
 import com.paypal.selion.annotations.MobileTest;
 import com.paypal.selion.configuration.Config;
+import com.paypal.selion.configuration.ExtendedConfig;
 import com.paypal.selion.configuration.Config.ConfigProperty;
 import com.paypal.selion.internal.utils.InvokedMethodInformation;
 import com.paypal.selion.logger.SeLionLogger;
@@ -136,7 +138,7 @@ public class MobileTestSession extends AbstractTestSession {
     @Override
     public void initializeTestSession(InvokedMethodInformation method) {
         logger.entering(method);
-        this.initTestSession(method);
+        initTestSession(method);
         MobileTest deviceTestAnnotation = method.getAnnotation(MobileTest.class);
 
         // First load these from the <test> local config
@@ -166,6 +168,8 @@ public class MobileTestSession extends AbstractTestSession {
                 this.deviceType = deviceTestAnnotation.deviceType();
             }
         }
+
+        initializeAdditionalCapabilities(deviceTestAnnotation.additionalCapabilities(), method);
         logger.exiting();
     }
 

--- a/client/src/main/java/com/paypal/selion/platform/grid/WebTestSession.java
+++ b/client/src/main/java/com/paypal/selion/platform/grid/WebTestSession.java
@@ -22,13 +22,11 @@ import java.util.Map;
 import java.util.logging.Level;
 
 import org.apache.commons.lang.StringUtils;
-import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.testng.IInvokedMethod;
 
 import com.paypal.selion.annotations.WebTest;
 import com.paypal.selion.configuration.Config;
-import com.paypal.selion.configuration.ExtendedConfig;
 import com.paypal.selion.configuration.Config.ConfigProperty;
 import com.paypal.selion.internal.utils.InvokedMethodInformation;
 import com.paypal.selion.reports.runtime.WebReporter;
@@ -62,7 +60,7 @@ public class WebTestSession extends AbstractTestSession {
     @Override
     public void initializeTestSession(InvokedMethodInformation method, Map<String, SeLionSession> sessionMap) {
         logger.entering(new Object[] { method, sessionMap });
-        this.initTestSession(method);
+        initTestSession(method);
         WebTest webTestAnnotation = method.getAnnotation(WebTest.class);
         // Setting the browser value
         this.browser = getLocalConfigProperty(ConfigProperty.BROWSER);
@@ -72,15 +70,6 @@ public class WebTestSession extends AbstractTestSession {
             }
             this.openNewSession = webTestAnnotation.openNewSession();
             this.keepSessionOpen = webTestAnnotation.keepSessionOpen();
-            if (webTestAnnotation.additionalCapabilities().length != 0) {
-                Map<String, String> capabilityMap = parseIntoCapabilities(webTestAnnotation.additionalCapabilities());
-                // We found some capabilities. Lets merge them.
-                this.additionalCapabilities.merge(new DesiredCapabilities(capabilityMap));
-            }
-            Object additionalCaps = method.getTestAttribute(ExtendedConfig.CAPABILITIES.getConfig());
-            if (additionalCaps instanceof DesiredCapabilities) {
-                this.additionalCapabilities.merge((DesiredCapabilities) additionalCaps);
-            }
 
             if (webTestAnnotation.browserHeight() > 0 && webTestAnnotation.browserWidth() > 0) {
                 this.browserHeight = webTestAnnotation.browserHeight();
@@ -89,6 +78,7 @@ public class WebTestSession extends AbstractTestSession {
                 warnUserOfInvalidBrowserDimensions(webTestAnnotation);
             }
 
+            initializeAdditionalCapabilities(webTestAnnotation.additionalCapabilities(), method);
         }
 
         setSessionName(sessionMap, method);

--- a/client/src/test/java/com/paypal/selion/platform/grid/AbstractTestSessionTest.java
+++ b/client/src/test/java/com/paypal/selion/platform/grid/AbstractTestSessionTest.java
@@ -50,7 +50,8 @@ public class AbstractTestSessionTest {
         assertNotNull(session.getAdditionalCapabilities(), "verify that the additional capabilities are not null");
         assertEquals(session.getAdditionalCapabilities().getCapability("key1"), "value1",
                 "verify the capability is read correctly");
-
+        assertEquals(session.getAdditionalCapabilities().getCapability("key2"), "value2",
+                "verify the capability is read correctly");
     }
 
     @WebTest

--- a/client/src/test/java/com/paypal/selion/platform/grid/WebTestTest.java
+++ b/client/src/test/java/com/paypal/selion/platform/grid/WebTestTest.java
@@ -95,15 +95,23 @@ public class WebTestTest {
     }
 
     @Test(groups = "functional")
-    @WebTest(additionalCapabilities = { "useCaps:true" })
+    @WebTest(additionalCapabilities = { "useBooleanCaps:true","useStringCaps:'true'" })
     public void testCapabilityViaAnnotation() {
-        assertEquals(Grid.getWebTestSession().getAdditionalCapabilities().getCapability("useCaps"), "true");
+        assertEquals(Grid.getWebTestSession().getAdditionalCapabilities().getCapability("useBooleanCaps"), Boolean.TRUE);
+        assertEquals(Grid.getWebTestSession().getAdditionalCapabilities().getCapability("useStringCaps"), "true");
+    }
+    
+    @Test(groups = "functional")
+    @WebTest(additionalCapabilities = { "name:a:b"})
+    public void testCapabilityWithColonInValue() {
+        assertEquals(Grid.getWebTestSession().getAdditionalCapabilities().getCapability("name"), "a:b");
     }
 
     @Test(testName = "testCapabilityViaTestResult", groups = "functional")
     @WebTest
     public void testCapabilityViaTestResult() {
-        assertEquals(Grid.getWebTestSession().getAdditionalCapabilities().getCapability("useCaps"), "true");
+        assertEquals(Grid.getWebTestSession().getAdditionalCapabilities().getCapability("useBooleanDCCaps"), Boolean.TRUE);
+        assertEquals(Grid.getWebTestSession().getAdditionalCapabilities().getCapability("useStringDCCaps"), "true");
     }
 
     @BeforeMethod(alwaysRun = true)
@@ -111,7 +119,8 @@ public class WebTestTest {
         Test test = method.getAnnotation(Test.class);
         if (test != null && test.testName().equalsIgnoreCase("testCapabilityViaTestResult")) {
             DesiredCapabilities dc = new DesiredCapabilities();
-            dc.setCapability("useCaps", "true");
+            dc.setCapability("useStringDCCaps", "true");
+            dc.setCapability("useBooleanDCCaps", Boolean.TRUE);
             testResult.setAttribute(ExtendedConfig.CAPABILITIES.getConfig(), dc);
         }
     }

--- a/client/src/test/java/com/paypal/selion/platform/grid/browsercapabilities/CapabilitiesHelperTest.java
+++ b/client/src/test/java/com/paypal/selion/platform/grid/browsercapabilities/CapabilitiesHelperTest.java
@@ -63,7 +63,7 @@ public class CapabilitiesHelperTest {
         for (DesiredCapabilities eachItem : list) {
             if (eachItem.is("is-oss")) {
                 found = true;
-                assertEquals(eachItem.getCapability("is-oss"), "true");
+                assertEquals(eachItem.getCapability("is-oss"), Boolean.TRUE);
                 break;
             }
         }


### PR DESCRIPTION
- Add support for 'additionalCapabilities' annotation parameter to @MobileTest so that users can set additional DesiredCapabilities.
- Add support for boolean DesiredCapabilities.
- Allow colons to be in the value part of name:value

NOTE: I changed the order of priority.  DesiredCapbilities from annotation param now takes priority over DesiredCapabilites from ExtendedConfig.  Makes mores sense for the lowest level to take precedence in value over higher level.  This may break existing user's if they specified the same desiredcapability in ExtendedConfig and in annotation parameter.
