### PR TITLE
RuntimeReporter has skipped tests also marked as running when test run is complete

### DIFF
--- a/client/src/main/java/com/paypal/selion/reports/reporter/runtimereport/JsonRuntimeReporterHelper.java
+++ b/client/src/main/java/com/paypal/selion/reports/reporter/runtimereport/JsonRuntimeReporterHelper.java
@@ -172,11 +172,6 @@ public class JsonRuntimeReporterHelper {
             return;
         }
 
-        if (result.getStatus() == ITestResult.SKIP) {
-            appendFile(jsonCompletedTest, test1.toJson().concat(",\n"));
-            return;
-        }
-
         for (TestMethodInfo temp : runningTest) {
             if (temp.getResult().equals(result)) {
                 runningTest.remove(temp);


### PR DESCRIPTION
Runtime Reporter: skipped tests need to be removed from running tests list so that the report doesn't leave skipped tests marked as running.
