### PR TITLE
Address possible issue in codegen if basePackage is empty

### DIFF
--- a/codegen/src/main/java/com/paypal/selion/plugins/CodeGeneratorMojo.java
+++ b/codegen/src/main/java/com/paypal/selion/plugins/CodeGeneratorMojo.java
@@ -79,7 +79,7 @@ public class CodeGeneratorMojo extends AbstractMojo {
     }
 
     public void setDetailedTextOutputLocation(File location) {
-        this.detailedTextOutputLocation = location;
+        detailedTextOutputLocation = location;
     }
 
     public void displayProjectInformation() {
@@ -124,11 +124,8 @@ public class CodeGeneratorMojo extends AbstractMojo {
      * @see org.apache.maven.plugin.AbstractMojo#execute()
      */
     public void execute() throws MojoExecutionException {
-
-        // iff basePackage is null, empty, or just whitespace reset it to the default value
-        basePackage = StringUtils.defaultString(basePackage, "com.paypal.selion.testcomponents");
-        // iff baseFolder is null, empty, or just whitespace reset it to the default value
-        baseFolder = StringUtils.defaultString(baseFolder, "GUIData");
+        // iff baseFolder is null or empty, reset it to the default value
+        baseFolder = StringUtils.defaultIfEmpty(baseFolder, "GUIData");
 
         Logger.setLogger(getLog());
         Log logger = Logger.getLogger();
@@ -164,10 +161,11 @@ public class CodeGeneratorMojo extends AbstractMojo {
                 if (generateJavaCode(baseFile, dataFile, extendedFile)) {
                     logger.info("Generating java file for YAML file [" + dataFile.getName() + "] in domain ["
                             + domain + "]");
-                    
+
                     String tempPackage = basePackage;
+                    // add the folder, iff it contains a value
                     if (!folder.isEmpty()) {
-                        tempPackage += "." + folder;
+                        tempPackage += tempPackage.isEmpty() ?  folder :  "." + folder;
                     }
                     helper.generateNewCode(dataFile, relativePath, tempPackage, domain);
                 }

--- a/codegen/src/main/java/com/paypal/selion/plugins/package-info.java
+++ b/codegen/src/main/java/com/paypal/selion/plugins/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * This package houses the primary classes for the SeLion Code Generator Maven Mojo
+ *
+ */
+package com.paypal.selion.plugins;

--- a/codegen/src/main/java/com/paypal/selion/reader/package-info.java
+++ b/codegen/src/main/java/com/paypal/selion/reader/package-info.java
@@ -1,5 +1,5 @@
 /**
- * This package houses all of the Yaml file reading logic.
+ * This package houses all of the YAML file reading logic.
  *
  */
 package com.paypal.selion.reader;

--- a/codegen/src/main/resources/Class.vm
+++ b/codegen/src/main/resources/Class.vm
@@ -1,4 +1,6 @@
+#if (!$package.equals(""))
 package $package;
+#end
 
 import $baseclasspackage;
 #foreach ($data in $control)

--- a/codegen/src/main/resources/ClassIOSDef.vm
+++ b/codegen/src/main/resources/ClassIOSDef.vm
@@ -1,4 +1,6 @@
+#if (!$package.equals(""))
 package $package;
+#end
 
 import $baseclasspackage;
 import com.paypal.selion.platform.html.support.HtmlElementUtils;


### PR DESCRIPTION
With this change a user can specify `-Dselion-code-generator.basePackage=`
in the `mvn generate-sources` step. The resulting java files will have a
`package` line created entirely from the folder structure under the `baseFolder`
Furthermore, if there are files in `baseFolder`, they will end up in the
default package.
