### PR TITLE
Add documentation for the customElements option in the SeLion-Code-Generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ test-output/
 target/
 selionFiles/
 logs/
+_site
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'github-pages'

--- a/html/whatIsCodeGenerator.html
+++ b/html/whatIsCodeGenerator.html
@@ -56,6 +56,12 @@
       Each domain is represented by a directory under <code>src/main/resources/GUIData</code>.
       <pre data-src="../sample-files/whatIsCodeGenerator-sample5.xml" data-line="15-18" class="line-numbers"></pre>
     </li>
+    <li><a name="customElements"><code>&lt;customElements /&gt;</code> - This configuration parameter represents the list of custom elements, that will be registered to the code generator.
+      Each custom element should extend the <code>AbstractElement</code>, be sure to implement all constructors.
+      <pre data-src="../sample-files/whatIsCodeGenerator-sample6.xml" data-line="15-18" class="line-numbers"></pre>
+      Custom element sample.
+      <pre data-src="../sample-files/whatIsCodeGenerator-sample-element.java"></pre>
+    </li>
   </ul>
   <h2>Put the SeLion Code Generator in Action</h2>
   <ol>

--- a/html/yamlpage.html
+++ b/html/yamlpage.html
@@ -116,6 +116,13 @@
       elements please take a look at the section -- <a href="#containers">PageYAML and Container Elements</a>.
     </li>
   </ul>
+
+  <h2>How to use custom elements in your page yaml.</h2>
+  <p>Please make sure that you register your custom elements as described in the <a href="#what-is-code-generator">SeLion's Code Generator</a> documentation. Once done you can use your custom elements, just like the elements that are provided by SeLion. Let's say we registered a custom element named <code>com.paypal.test.CustomButton</code>, to SeLion's code generator.</p>
+
+  <p>We can then use the following Yaml to generate a page object which makes use of our CustomButton.</p>
+  <pre data-src="../sample-files/yamlpage-sample2.yaml" class="language-markup"></pre>
+  <p>The element will then be accesible through a getter method, in the generated page object.</p>
 </div>
 
 <script src="../js/prismjs-min.js"></script>

--- a/sample-files/whatIsCodeGenerator-sample-element.java
+++ b/sample-files/whatIsCodeGenerator-sample-element.java
@@ -1,0 +1,24 @@
+package com.paypal.test;
+
+import com.paypal.selion.platform.html.AbstractElement;
+import com.paypal.selion.platform.html.ParentTraits;
+
+public class CustomElementOne extends AbstractElement {
+
+    public CustomElementOne(ParentTraits parent, String locator) {
+        super(parent, locator);
+    }
+
+    public CustomElementOne(String locator, String controlName, ParentTraits parent) {
+        super(locator, controlName, parent);
+    }
+
+    public CustomElementOne(String locator, String controlName) {
+        super(locator, controlName);
+    }
+
+    public CustomElementOne(String locator) {
+        super(locator);
+    }
+
+}

--- a/sample-files/whatIsCodeGenerator-sample6.xml
+++ b/sample-files/whatIsCodeGenerator-sample6.xml
@@ -1,0 +1,20 @@
+<plugin>
+  <groupId>com.paypal.selion</groupId>
+  <artifactId>SeLion-Code-Generator</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <executions>
+    <execution>
+      <phase>generate-sources</phase>
+      <goals>
+        <goal>generate</goal>
+      </goals>
+    </execution>
+  </executions>
+  <configuration>
+    <basePackage>com.mycompany</basePackage>
+    <customElements>
+      <customElement>com.paypal.test.CustomButton</customElement>
+      <customElement>com.paypal.test.CustomSelectList</customElement>
+    </customElements>
+  </configuration>
+</plugin>

--- a/sample-files/yamlpage-sample2.yaml
+++ b/sample-files/yamlpage-sample2.yaml
@@ -1,0 +1,7 @@
+baseClass: "com.paypal.selion.testcomponents.BasicPageImpl"
+pageTitle:
+  US: "API Page"
+elements:
+  submitCustomButton:
+    locators:
+      US: "name=submit"


### PR DESCRIPTION
Documentation for the new functionality introduced in #90, currently I add the documentation to the existing configuration parameters section. Please let me know if the custom element should get it's own section in the documentation.

The Gemfile will help users to install Jekyll so that contributors can easily contribute to the documentation. [More info](https://help.github.com/articles/using-jekyll-with-pages/) 
