### PR TITLE
Added summary counts from test results to report.json.

### DIFF
--- a/client/src/main/java/com/paypal/selion/reports/reporter/runtimereport/JsonRuntimeReporterHelper.java
+++ b/client/src/main/java/com/paypal/selion/reports/reporter/runtimereport/JsonRuntimeReporterHelper.java
@@ -362,9 +362,14 @@ public class JsonRuntimeReporterHelper {
             configObjects.add(gson.fromJson (temp.toJson(), JsonElement.class));
         }
         
+        JsonObject summary = new JsonObject();
+        summary.add("testMethodsSummary", getReportSummaryCounts(testObjects));
+        summary.add("configurationMethodsSummary", getReportSummaryCounts(configObjects));
+        
         JsonElement reportMetadata = gson.fromJson(ReporterConfigMetadata.toJsonAsString(), JsonElement.class);
         
         JsonObject reporter = new JsonObject();
+        reporter.add("reportSummary", summary);
         reporter.add("testMethods", testObjects);
         reporter.add("configurationMethods", configObjects);
         reporter.add("configSummary", generateConfigSummary());
@@ -374,6 +379,56 @@ public class JsonRuntimeReporterHelper {
         logger.exiting(reporter);
 
         return reporter;
+    }
+
+    /**
+     * Provides a JSON object representing the counts of tests passed, failed,
+     * skipped and running.
+     * 
+     * @param testObjects
+     *            Array of the current tests as a {@link JsonArray}.
+     * @return
+     *            A {@link JsonObject} with counts for various test results.
+     */
+    private JsonObject getReportSummaryCounts(JsonArray testObjects) {
+        logger.entering(testObjects);
+
+        int runningCount = 0;
+        int skippedCount = 0;
+        int passedCount = 0;
+        int failedCount = 0;
+        String result;
+        
+        for (JsonElement test : testObjects) {
+            result = test.getAsJsonObject().get("status").getAsString();
+            switch (result) {
+            case "Running":
+                runningCount += 1;
+                break;
+            case "Passed":
+                passedCount += 1;
+                break;
+            case "Failed":
+                failedCount += 1;
+                break;
+            case "Skipped":
+                skippedCount += 1;
+                break;
+            default:
+                logger.warning("Found invalid status of the test being run. Status: " + result);
+            }
+        }
+        
+        JsonObject testSummary = new JsonObject();
+        if (0 < runningCount) {
+            testSummary.addProperty("running", runningCount);
+        }
+        testSummary.addProperty("passed", passedCount);
+        testSummary.addProperty("failed", failedCount);
+        testSummary.addProperty("skipped", skippedCount);
+
+        logger.exiting(testSummary);
+        return testSummary;
     }
 
     /**


### PR DESCRIPTION
Adds following block at the begin of report.json. The 'running' in included only when running count is greater than 0.
"reportSummary": {
 "testMethodsSummary": { "running":1, "passed": 5, "failed": 0, "skipped": 0 },
"configurationMethodsSummary": { "passed": 1, "failed": 0, "skipped": 0 }
},
...
