### PR TITLE
Put the SoftAssert error messages in one Log message instead of on multiple lines.

### DIFF
--- a/client/src/main/java/com/paypal/selion/platform/asserts/SeLionSoftAssert.java
+++ b/client/src/main/java/com/paypal/selion/platform/asserts/SeLionSoftAssert.java
@@ -108,12 +108,14 @@ class SeLionSoftAssert extends Assertion {
             }
             sb.append("failed because the expected value of [").append(eachAssert.getExpected()).append("] ");
             sb.append("was different from the actual value [").append(eachAssert.getActual()).append("]");
-            Reporter.log(sb.toString(), true);
-            Reporter.log("StackTrace as below", true);
+            
+            sb.append("\n").append("StackTrace as below");
+            
             StringWriter sw = new StringWriter();
             eachError.printStackTrace(new PrintWriter(sw));
-            Reporter.log(sw.toString(), true);
-
+            
+            sb.append("\n").append(sw.toString());
+            Reporter.log(sb.toString(), true);
         }
         result.setStatus(ITestResult.FAILURE);
     }


### PR DESCRIPTION
In the runtime report the SoftAssert messages will be shown on one line as followed:

```
{
    "message": "The validation failed because the expected value of [true] was different from the actual value [false]\nStackTrace as below\njava.lang.AssertionError: expected [true] but found [false]
}
```

instead of splitting it over over multiple messages.

```
{
    "message": "The validation failed because the expected value of [true] was different from the actual value [false]"
},
{
    "message": "StackTrace as below"
},
{
    "message": "java.lang.AssertionError: expected [true] but found [false]"
}
```
