### PR TITLE
RuntimeReporter: add tooltip to display passed/fail information

### DIFF
--- a/client/src/main/resources/templates/RuntimeReporter/index.html
+++ b/client/src/main/resources/templates/RuntimeReporter/index.html
@@ -309,8 +309,8 @@
             </thead>
             <tbody>
                 {{for results}}
-                <tr>
-                    <td><span class="label label-{{if status == "Passed" }}success{{else status == "Failed"}}danger{{else status == "Skipped"}}warning{{else}}info{{/if}}">{{:#index+~startIndex}}</span></td>
+                <tr data-toggle="tooltip" title="{{:status}}">
+                    <td><span class="label label-{{if status == "Passed" }}success{{else status == "Failed"}}danger{{else status == "Skipped"}}warning{{else}}info{{/if}}" data-toggle="tooltip" title="{{:status}}">{{:#index+~startIndex}}</span></td>
                     <td>{{:suite}}</td>
                     <td>{{:test}}</td>
                     <td>{{:packageInfo}}</td>


### PR DESCRIPTION
Added tool tip for the whole row in addition to just hovering over the colored numeric icon.  If a td object has a specified tool tip, that overrides the row's tooltip as intended.
