### PR TITLE
Fix #143: Use the webtest params with shared sessions

### DIFF
--- a/client/src/main/java/com/paypal/selion/platform/grid/WebTestSession.java
+++ b/client/src/main/java/com/paypal/selion/platform/grid/WebTestSession.java
@@ -53,6 +53,10 @@ public class WebTestSession extends AbstractTestSession {
 
         this.initTestSession(method);
         WebTest webTestAnnotation = method.getAnnotation(WebTest.class);
+        // check class has webtest annotation (i.e. using shared sessions)
+        if (webTestAnnotation == null) {
+            webTestAnnotation = method.getActualMethod().getDeclaringClass().getAnnotation(WebTest.class);
+        }
         // Setting the browser value
         this.browser = getLocalConfigProperty(ConfigProperty.BROWSER);
         if (webTestAnnotation != null) {

--- a/client/src/test/java/com/paypal/selion/platform/grid/SessionSharingTest.java
+++ b/client/src/test/java/com/paypal/selion/platform/grid/SessionSharingTest.java
@@ -26,7 +26,7 @@ import com.paypal.selion.TestServerUtils;
 import com.paypal.selion.annotations.WebTest;
 import com.paypal.selion.reports.runtime.SeLionReporter;
 
-@WebTest
+@WebTest(browser = "chrome")
 @Test(singleThreaded = true)
 public class SessionSharingTest {
 
@@ -45,7 +45,12 @@ public class SessionSharingTest {
         // should already be on test Page
         SeLionReporter.log("Editable Test Page (" + getSessionId() + ")", true, true);
         assertTrue(Grid.driver().getTitle().contains("Sample Unit Test Page"),
-                "shuold be on Sample Unit Test Page already with this session");
+                "should be on Sample Unit Test Page already with this session");
+    }
+
+    @Test(groups = { "functional" }, priority = 3, dependsOnMethods = "testSessionSharing_part2")
+    public void testSessionSharing_part3() throws Exception {
+        assertTrue(Grid.driver().getCapabilities().getBrowserName().contains("chrome"), "Should be using chrome browser.");
     }
 
 }


### PR DESCRIPTION
Attempt to read the webtest annotation from class if here is no method
annotation present.
