### PR TITLE
Fix #31 Allow users to specify log file size and count

### DIFF
--- a/common/src/main/java/com/paypal/selion/configuration/LoggerConfig.java
+++ b/common/src/main/java/com/paypal/selion/configuration/LoggerConfig.java
@@ -60,7 +60,18 @@ public final class LoggerConfig {
         /**
          * The logs directory of SeLion
          */
-        LOGS_DIR("logsDir", "selionFiles/selionLogs");
+        LOGS_DIR("logsDir", "selionFiles/selionLogs"),
+
+        /**
+         * The maximum size in MB for the log file. Default is 0 denoting unlimited
+         */
+        LOGS_MAX_SIZE("logsMaxSize", "0"),
+
+        /**
+         * The maximum limit to the number of files to create for storing logs once the current log file reaches
+         * {@link LOGS_MAX_SIZE}
+         */
+        LOGS_MAX_FILE_COUNT("logsMaxFileCount", "1");
 
         private final String propertyName;
         private final String defaultValue;

--- a/common/src/main/java/com/paypal/selion/logger/SeLionLogger.java
+++ b/common/src/main/java/com/paypal/selion/logger/SeLionLogger.java
@@ -23,6 +23,7 @@ import java.util.logging.SimpleFormatter;
 import com.paypal.selion.SeLionBuildInfo;
 import com.paypal.selion.SeLionBuildInfo.SeLionBuildProperty;
 import com.paypal.selion.configuration.LoggerConfig;
+import com.paypal.selion.configuration.LoggerConfig.LoggerProperties;
 import com.paypal.test.utilities.logging.SimpleLogger;
 import com.paypal.test.utilities.logging.SimpleLoggerEvents;
 import com.paypal.test.utilities.logging.SimpleLoggerSettings;
@@ -57,6 +58,8 @@ public final class SeLionLogger {
                     .getConfigProperty(LoggerConfig.LoggerProperties.LOG_LEVEL_USER)));
             this.setSimpleLoggerEventsImpl(new SeLionLoggerEventsImpl());
             this.setIdentifier(SeLionBuildInfo.getBuildValue(SeLionBuildProperty.SELION_VERSION));
+            this.setMaxFileSize(Integer.parseInt(LoggerConfig.getConfigProperty(LoggerProperties.LOGS_MAX_SIZE)));
+            this.setMaxFileCount(Integer.parseInt(LoggerConfig.getConfigProperty(LoggerProperties.LOGS_MAX_FILE_COUNT)));
             String log2Console = LoggerConfig.getConfigProperty(LoggerConfig.LoggerProperties.LOG_TO_CONSOLE);
             if (log2Console.equalsIgnoreCase("dev")) {
                 this.setLog2Console(ConsoleLevel.DEV);


### PR DESCRIPTION
- Added new values to LoggerProperties enum
- utilized the new properties when initializing the logger
