### PR TITLE
Fix #156 - Allow access to Grid session in `@BeforeClass` and `@After…

### DIFF
--- a/client/src/main/resources/templates/RuntimeReporter/index.html
+++ b/client/src/main/resources/templates/RuntimeReporter/index.html
@@ -356,6 +356,9 @@
                     <td>{{:methodName}}</td>
                     <td>{{:type}}</td>
                     <td>
+                    {{if logs != null}}
+                        <button type="button" data-index="{{:#parent.index}}" class="btn btn-default btn-xs btn-screenshot-config" data-toggle="tooltip" data-placement="top" title="Reporter Output"><span class="glyphicon glyphicon-picture"></span></button>
+                    {{/if}}
                     {{if status == "Failed" }}
                         <button type="button" data-index="{{:#parent.index}}" class="btn btn-default btn-xs btn-stacktrace-config" data-toggle="tooltip" data-placement="top" title="Stacktrace"><span class="glyphicon glyphicon-warning-sign"></span></button>
                     {{/if}}

--- a/client/src/main/resources/templates/js/main.js
+++ b/client/src/main/resources/templates/js/main.js
@@ -601,7 +601,7 @@ function displaySource(src, title) {
     $('.btn-screenshot' + buttonAdditonalClassName).click(function() {
       var testcase = data[parseInt($(this).attr('data-index'))];
       var params = ' ';
-      if (testcase.parameters !== null) {
+      if (testcase.parameters) {
         params = testcase.parameters;
       }
       $('.modal-screenshot .modal-header .modal-title').text(
@@ -613,7 +613,7 @@ function displaySource(src, title) {
     $('.btn-stacktrace' + buttonAdditonalClassName).click(function() {
       var testcase = data[parseInt($(this).attr('data-index'))];
       var params = ' ';
-      if (testcase.parameters !== null) {
+      if (testcase.parameters) {
         params = testcase.parameters;
       }
       $('.modal-stacktrace .modal-header .modal-title').text(

--- a/client/src/test/java/com/paypal/selion/platform/grid/SessionSharingTestWithConfigurationMethods.java
+++ b/client/src/test/java/com/paypal/selion/platform/grid/SessionSharingTestWithConfigurationMethods.java
@@ -17,9 +17,18 @@ package com.paypal.selion.platform.grid;
 
 import static org.testng.Assert.assertTrue;
 
-import java.io.IOException;
-
 import org.openqa.selenium.remote.SessionId;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterGroups;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeGroups;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import com.paypal.selion.TestServerUtils;
@@ -28,30 +37,89 @@ import com.paypal.selion.reports.runtime.SeLionReporter;
 
 @WebTest(browser = "chrome")
 @Test(singleThreaded = true, groups = "functional")
-public class SessionSharingTest {
+public class SessionSharingTestWithConfigurationMethods {
 
-    @Test(priority = 1)
-    public void testSessionSharing_part1() {
+    @BeforeSuite
+    public void beforeSuite() {
+        // not started yet
+        Assert.assertNull(Grid.getTestSession());
+    }
+
+    @BeforeTest
+    public void beforeTest() {
+        // not started yet
+        Assert.assertNull(Grid.getTestSession());
+    }
+
+    @BeforeGroups
+    public void beforeGroups() {
+        /*
+         * Not predictable. May or may not have an active Grid WD session. Depends on which thread this method is
+         * invoked from. SeLion session sharing tests must be on the same thread per @Test class. TestNG does not
+         * guarantee which thread @BeforeGroups is invoked from.
+         */
+    }
+
+    @BeforeClass
+    public void beforeClass() {
+        // session started
         Grid.open(TestServerUtils.getTestEditableURL());
         SeLionReporter.log("Editable Test Page (" + getSessionId() + ")", true, true);
     }
 
-    private SessionId getSessionId() {
-        return Grid.driver().getSessionId();
+    @BeforeMethod
+    public void beforeMethod() {
+        // session started by now, when beforeClass is present
+        Assert.assertNotNull(Grid.getTestSession());
     }
 
-    @Test(priority = 2)
-    public void testSessionSharing_part2() throws IOException {
-        // should already be on test Page
+    @Test(priority = 0)
+    public void testSessionSharing_part1() {
         SeLionReporter.log("Editable Test Page (" + getSessionId() + ")", true, true);
         assertTrue(Grid.driver().getTitle().contains("Sample Unit Test Page"),
                 "should be on Sample Unit Test Page already with this session");
     }
 
-    @Test(priority = 3)
-    public void testSessionSharing_part3() throws Exception {
+    @Test(priority = 1)
+    public void testSessionSharing_part2() throws Exception {
         assertTrue(Grid.driver().getCapabilities().getBrowserName().contains("chrome"),
                 "Should be using chrome browser.");
     }
 
+    @AfterMethod
+    public void afterMethod() {
+        // started by now, regardless if beforeClass is present
+        Assert.assertNotNull(Grid.getTestSession());
+    }
+
+    @AfterClass
+    public void afterClass() {
+        // session still available, closed after this method
+        Assert.assertNotNull(Grid.getTestSession());
+    }
+
+    @AfterGroups
+    public void afterGroups() {
+        /*
+         * Not predictable. May or may not have an active Grid WD session. Depends on which thread this method is
+         * invoked from. SeLion session sharing tests must be on the same thread per @Test class. TestNG does not
+         * guarantee which thread @AfterGroups is invoked from.
+         */
+    }
+
+    @AfterTest
+    public void afterTest() {
+        // session closed by now
+        Assert.assertNull(Grid.getTestSession());
+    }
+
+    @AfterSuite
+    public void afterSuite() {
+        // closed by now
+        Assert.assertNull(Grid.getTestSession());
+    }
+
+    private SessionId getSessionId() {
+        return Grid.driver().getSessionId();
+    }
 }

--- a/client/src/test/java/com/paypal/selion/platform/grid/SessionSharingTestWithDataProvider.java
+++ b/client/src/test/java/com/paypal/selion/platform/grid/SessionSharingTestWithDataProvider.java
@@ -25,15 +25,16 @@ import com.paypal.selion.TestServerUtils;
 import com.paypal.selion.annotations.WebTest;
 
 @WebTest
-@Test(singleThreaded = true)
+@Test(singleThreaded = true, groups = "functional")
 public class SessionSharingTestWithDataProvider {
 
     private static int flag = 0;
     private String[] sitesToOpen = null;
 
-    @BeforeClass(groups = "functional")
-    public void initURL() {
+    @BeforeClass
+    public void beforeClass() {
         sitesToOpen = new String[] { TestServerUtils.getContainerURL(), TestServerUtils.getTestEditableURL() };
+        Assert.assertNotNull(Grid.getTestSession());
     }
 
     @DataProvider(name = "testData")
@@ -41,7 +42,7 @@ public class SessionSharingTestWithDataProvider {
         return new Object[][] { { "ElementList Unit Test Page" }, { "Sample Unit Test Page" } };
     }
 
-    @Test(priority = 0, dataProvider = "testData", groups = "functional")
+    @Test(priority = 0, dataProvider = "testData")
     public void testSessionSharingWithDpAlone(String title) {
         Grid.driver().get(sitesToOpen[flag]);
         Assert.assertTrue(Grid.driver().getTitle().contains(title));
@@ -49,7 +50,7 @@ public class SessionSharingTestWithDataProvider {
     }
 
     @AfterClass
-    public void tearDown() {
+    public void afterClass() {
         flag = 0;
     }
 }

--- a/client/src/test/java/com/paypal/selion/platform/grid/SessionSharingTestWithDataProviderMixedIn.java
+++ b/client/src/test/java/com/paypal/selion/platform/grid/SessionSharingTestWithDataProviderMixedIn.java
@@ -26,7 +26,7 @@ import com.paypal.selion.TestServerUtils;
 import com.paypal.selion.annotations.WebTest;
 
 @WebTest
-@Test(singleThreaded = true)
+@Test(singleThreaded = true, groups = "functional")
 public class SessionSharingTestWithDataProviderMixedIn {
 
     private static int flag = 0;
@@ -37,9 +37,10 @@ public class SessionSharingTestWithDataProviderMixedIn {
         return Grid.driver().getSessionId();
     }
 
-    @BeforeClass(groups = "functional")
-    public void initURL() {
+    @BeforeClass
+    public void beforeClass() {
         sitesToOpen = new String[] { TestServerUtils.getContainerURL(), TestServerUtils.getTestEditableURL() };
+        Assert.assertNotNull(Grid.getTestSession());
     }
 
     @DataProvider(name = "testData")
@@ -47,14 +48,14 @@ public class SessionSharingTestWithDataProviderMixedIn {
         return new Object[][] { { "ElementList Unit Test Page" }, { "Sample Unit Test Page" } };
     }
 
-    @Test(priority = 0, groups = "functional")
+    @Test(priority = 0)
     public void testSessionSharingWithDPStart() {
         Grid.driver().get(TestServerUtils.getDatePickerURL());
         Assert.assertTrue(Grid.driver().getTitle().contains("jQuery Datepicker"));
         sessionId = getSessionId();
     }
 
-    @Test(priority = 1, dataProvider = "testData", groups = "functional")
+    @Test(priority = 1, dataProvider = "testData")
     public void testSessionSharingWithDp(String title) {
         Assert.assertEquals(getSessionId().toString(), sessionId.toString());
         Grid.driver().get(sitesToOpen[flag]);
@@ -62,7 +63,7 @@ public class SessionSharingTestWithDataProviderMixedIn {
         flag++;
     }
 
-    @Test(priority = 3, groups = "functional")
+    @Test(priority = 2)
     public void testSessionSharingWithDPFinal() {
         Assert.assertEquals(getSessionId().toString(), sessionId.toString());
         Grid.driver().get(TestServerUtils.getDatePickerURL());
@@ -70,7 +71,7 @@ public class SessionSharingTestWithDataProviderMixedIn {
     }
 
     @AfterClass
-    public void tearDown() {
+    public void afterClass() {
         flag = 0;
     }
 }

--- a/client/src/test/resources/suites/WebTestThreaded-Suite.xml
+++ b/client/src/test/resources/suites/WebTestThreaded-Suite.xml
@@ -1,6 +1,11 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
 <suite thread-count="7" verbose="1" name="WebTestThreaded Suite" skipfailedinvocationcounts="false" junit="false"
-    parallel="false" data-provider-thread-count="50" annotations="JDK">
+    parallel="classes" data-provider-thread-count="50" annotations="JDK">
+
+    <listeners>
+        <listener class-name="com.paypal.selion.reports.runtime.DebugListener" />
+    </listeners>
+
     <!-- SELENIUM CONFIGURATION -->
     <parameter name="browser" value="*chrome" />
 
@@ -11,7 +16,10 @@
             </run>
         </groups>
         <classes>
-            <class name="com.paypal.selion.platform.grid.SessionSharingTest"></class>
+            <class name="com.paypal.selion.platform.grid.SessionSharingTest" />
+            <class name="com.paypal.selion.platform.grid.SessionSharingTestWithConfigurationMethods" />
+            <class name="com.paypal.selion.platform.grid.SessionSharingTestWithDataProvider" />
+            <class name="com.paypal.selion.platform.grid.SessionSharingTestWithDataProviderMixedIn" />
         </classes>
     </test>
 

--- a/common/src/main/java/com/paypal/selion/reports/runtime/DebugListener.java
+++ b/common/src/main/java/com/paypal/selion/reports/runtime/DebugListener.java
@@ -1,5 +1,5 @@
 /*-------------------------------------------------------------------------------------------------------------------*\
-|  Copyright (C) 2014 PayPal                                                                                          |
+|  Copyright (C) 2014-15 PayPal                                                                                       |
 |                                                                                                                     |
 |  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
 |  with the License.                                                                                                  |
@@ -15,6 +15,9 @@
 
 package com.paypal.selion.reports.runtime;
 
+import org.testng.IConfigurationListener;
+import org.testng.ISuite;
+import org.testng.ISuiteListener;
 import org.testng.ITestContext;
 import org.testng.ITestListener;
 import org.testng.ITestResult;
@@ -24,45 +27,75 @@ import org.testng.annotations.Test;
 /**
  * A simple {@link ITestListener} which logs {@link Test} events to {@link Reporter#log(String)}
  */
-public class DebugListener implements ITestListener {
+public class DebugListener implements ITestListener, ISuiteListener, IConfigurationListener {
 
     @Override
     public void onFinish(ITestContext arg0) {
-        return;
+        System.out.println("<test> " + arg0.getName() + " finished");
     }
 
     @Override
     public void onStart(ITestContext arg0) {
+        System.out.println("about to start <test> " + arg0.getName());
     }
 
     @Override
     public void onTestFailedButWithinSuccessPercentage(ITestResult arg0) {
-        return;
+        Reporter.log(arg0.getTestClass().getName() + "." + arg0.getMethod().getMethodName() + " on thread "
+                + Thread.currentThread().getId() + " failed but within success percentage", true);
     }
 
     @Override
     public void onTestFailure(ITestResult arg0) {
-
-        Reporter.log(arg0.getTestClass().getName() + "." + arg0.getMethod().getMethodName() + " failed", true);
+        Reporter.log(arg0.getTestClass().getName() + "." + arg0.getMethod().getMethodName() + " on thread "
+                + Thread.currentThread().getId() + " failed", true);
         arg0.getThrowable().printStackTrace();
-
     }
 
     @Override
     public void onTestSkipped(ITestResult arg0) {
-        return;
+        Reporter.log(arg0.getTestClass().getName() + "." + arg0.getMethod().getMethodName() + " on thread "
+                + Thread.currentThread().getId() + " skipped", true);
     }
 
     @Override
     public void onTestStart(ITestResult arg0) {
-        Reporter.log("about to start test " + arg0.getTestClass().getName() + "." + arg0.getMethod().getMethodName(),
-                true);
-
+        Reporter.log("about to start test " + arg0.getTestClass().getName() + "." + arg0.getMethod().getMethodName()
+                + " on thread " + Thread.currentThread().getId(), true);
     }
 
     @Override
     public void onTestSuccess(ITestResult arg0) {
-        Reporter.log(arg0.getTestClass().getName() + "." + arg0.getMethod().getMethodName() + " passed", true);
+        Reporter.log(arg0.getTestClass().getName() + "." + arg0.getMethod().getMethodName() + " on thread "
+                + Thread.currentThread().getId() + " passed", true);
     }
 
+    @Override
+    public void onStart(ISuite suite) {
+        System.out.println("about to start <suite> " + suite.getName());
+    }
+
+    @Override
+    public void onFinish(ISuite suite) {
+        System.out.println("<suite> " + suite.getName() + " finished");
+    }
+
+    @Override
+    public void onConfigurationSuccess(ITestResult itr) {
+        System.out.println(itr.getTestClass().getName() + "." + itr.getMethod().getMethodName() + " on thread "
+                        + Thread.currentThread().getId() + " passed");
+    }
+
+    @Override
+    public void onConfigurationFailure(ITestResult itr) {
+        System.out.println(itr.getTestClass().getName() + "." + itr.getMethod().getMethodName() + " on thread "
+                        + Thread.currentThread().getId() + " failed");
+        itr.getThrowable().printStackTrace();
+    }
+
+    @Override
+    public void onConfigurationSkip(ITestResult itr) {
+        System.out.println(itr.getTestClass().getName() + "." + itr.getMethod().getMethodName() + " on thread "
+                        + Thread.currentThread().getId() + " skipped");
+    }
 }


### PR DESCRIPTION
…Class` when session sharing.

Also in this change set;
- Fix #158 - guard against `undefined` in `RuntimeReporter` html report
- Added support for 'Reporter Output' in configuration methods on `RuntimeReporter` html report
- Add more debug messages to `DebugListner`
