### PR TITLE
Revert change that throws illegalStateException

### DIFF
--- a/client/src/main/java/com/paypal/selion/platform/grid/Grid.java
+++ b/client/src/main/java/com/paypal/selion/platform/grid/Grid.java
@@ -85,11 +85,7 @@ public final class Grid {
         if (! testSession.isStarted()) {
             testSession.startSesion();
         }
-        RemoteWebDriver rwd = threadLocalWebDriver.get();
-        if (rwd == null) {
-            throw new IllegalStateException("Driver not initialized. Is @WebTest/@MobileTest missing on class/method?");
-        }
-        return rwd;
+        return threadLocalWebDriver.get();
     }
 
     /**

--- a/client/src/test/java/com/paypal/selion/platform/grid/GridTest.java
+++ b/client/src/test/java/com/paypal/selion/platform/grid/GridTest.java
@@ -48,11 +48,6 @@ public class GridTest {
         assertNotNull(Grid.driver(), "verify that the driver instance returned is not null");
     }
 
-    @Test(expectedExceptions = { IllegalStateException.class })
-    public void testGridDriverWithOutWebTest() {
-        Grid.driver().get("http://www.paypal.com");
-    }
-
     @WebTest
     @Test(groups = "functional")
     public void testGetTestSession() {


### PR DESCRIPTION
Reverting change to throw an illegalStateException in Grid.driver().
Internally in SeLion client testng listeners allow
Grid.driver() to return null WebDriver.
