### PR TITLE
Fix #169 : Upgraded TestNG version to 6.9.6

### DIFF
--- a/client/src/test/java/com/paypal/selion/internal/utils/TestNGUtilsTest.java
+++ b/client/src/test/java/com/paypal/selion/internal/utils/TestNGUtilsTest.java
@@ -34,8 +34,7 @@ public class TestNGUtilsTest {
     @Test(groups = "unit", dependsOnMethods = { "dummyTestMethod" })
     public void testGetInvokedMethodInformation() {
         ITestResult result = Reporter.getCurrentTestResult();
-        IInvokedMethod method = new InvokedMethod(this, result.getMethod(), null, true, false,
-                System.currentTimeMillis(), result);
+        IInvokedMethod method = new InvokedMethod(this, result.getMethod(), null, System.currentTimeMillis(), result);
         result.setAttribute("foo", "bar");
         InvokedMethodInformation response = TestNGUtils.getInvokedMethodInformation(method, result);
         SeLionAsserts.assertEquals(response.getCurrentTestName(), result.getTestContext().getCurrentXmlTest()

--- a/codegen/pom.xml
+++ b/codegen/pom.xml
@@ -61,6 +61,10 @@
                     <groupId>org.codehaus.plexus</groupId>
                     <artifactId>plexus-utils</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <iosdriver.version>0.6.5</iosdriver.version>
         <selendroid.version>0.15.0</selendroid.version>
         <appium.version>2.2.0</appium.version>
-        <testng.version>6.8.21</testng.version>
+        <testng.version>6.9.6</testng.version>
         <snakeyaml.version>1.15</snakeyaml.version>
         <project.bom.version>${project.version}</project.bom.version>
     </properties>


### PR DESCRIPTION
I tried to upgrade to TestNG version 6.9.4, but I had issue when loading listeners via ServiceLoaders. TestNG fixed the issue in 6.9.5, but this version require JDK8 to compile. So I have moved to TestNG version 6.9.6 which is compiled on JDK7 and everything is working fine.

Service Loader Issue and Fix: https://groups.google.com/forum/#!msg/testng-users/-fHtyj6EpLI/UjXXFy1d_wMJ
TestNG 6.9.5 on JDK8: https://groups.google.com/forum/#!topic/testng-users/l_YY-wt-Wl8
