### PR TITLE
Improved stacktraces for click and clickAndExpectOneOf

### DIFF
--- a/client/src/main/java/com/paypal/selion/platform/html/AbstractElement.java
+++ b/client/src/main/java/com/paypal/selion/platform/html/AbstractElement.java
@@ -25,6 +25,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.openqa.selenium.InvalidElementStateException;
 import org.openqa.selenium.NoAlertPresentException;
 import org.openqa.selenium.NoSuchElementException;
@@ -502,10 +504,11 @@ public abstract class AbstractElement implements Clickable, Hoverable {
                     ExpectedCondition<Boolean> condition = new ExpectedCondition<Boolean>() {
                         @Override
                         public Boolean apply(WebDriver webDriver) {
-                            return w.isCurrentPageInBrowser();
+                            w.validatePage();
+                            return true;
                         }
                     };
-                    new WebDriverWait(Grid.driver(), timeOutInSeconds).until(condition);
+                    new WebDriverWait(Grid.driver(), timeOutInSeconds).ignoring(PageValidationException.class).until(condition);
                 }
             }
         } finally {
@@ -646,12 +649,20 @@ public abstract class AbstractElement implements Clickable, Hoverable {
         long timeout = Grid.getExecutionTimeoutValue() / 1000;
 
         try {
+            
+            
             WebDriverWait wait = new WebDriverWait(Grid.driver(), timeout);
-            Object expectedObj = wait.until(new Function<WebDriver, Object>() {
+            wait.ignoring(NoSuchElementException.class);
+            wait.ignoring(PageValidationException.class);
+            
+            Object expectedObj = wait.ignoring(ExpectOneOfException.class).until(new Function<WebDriver, Object>() {
 
                 // find the first object that is matched and return it
                 @Override
                 public Object apply(WebDriver webDriver) {
+                    StringBuilder sb = new StringBuilder();
+                    
+                    int i = 1;
                     for (Object expect : expected) {
                         try {
                             if (expect instanceof AbstractElement) {
@@ -667,14 +678,19 @@ public abstract class AbstractElement implements Clickable, Hoverable {
                             } else if (expect instanceof WebPage) {
                                 WebPage w = (WebPage) expect;
 
-                                if (w.isCurrentPageInBrowser()) {
-                                    return expect;
-                                }
+                                w.validatePage();
+                                return expect;
                             }
-                        } catch (NoSuchElementException e) { // NOSONAR
+                        } catch (NoSuchElementException | PageValidationException e) { // NOSONAR
+                            sb.append("\n\tObject " + i + ": " + expect.getClass().getSimpleName() + "\n");
+                            sb.append("\t" + ExceptionUtils.getRootCauseMessage(e) + "\n");
+                            sb.append("\t\t" + StringUtils.substringBetween(ExceptionUtils.getStackTrace(e), "\n"));
                         }
+                        
+                        i++;
                     }
-                    return null;
+
+                    throw new ExpectOneOfException(sb.toString());
                 }
             });
 

--- a/client/src/main/java/com/paypal/selion/platform/html/ExpectOneOfException.java
+++ b/client/src/main/java/com/paypal/selion/platform/html/ExpectOneOfException.java
@@ -1,0 +1,13 @@
+package com.paypal.selion.platform.html;
+
+public class ExpectOneOfException extends RuntimeException {
+
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 4504271723751959171L;
+
+    public ExpectOneOfException(String msg) {
+        super(msg);
+    }
+}

--- a/client/src/main/java/com/paypal/selion/testcomponents/BasicPageImpl.java
+++ b/client/src/main/java/com/paypal/selion/testcomponents/BasicPageImpl.java
@@ -188,25 +188,25 @@ public abstract class BasicPageImpl extends AbstractPage implements ParentTraits
         case "isPresent":
             if (!present) {
                 throw new PageValidationException(getClass().getSimpleName() + " isn't loaded in the browser, "
-                        + elementName + " isn't present.");
+                        + elementName + " with locator " + element.getLocator() + " isn't present.");
             }
             break;
         case "isVisible":
             if (!present || (present && !element.isVisible())) {
                 throw new PageValidationException(getClass().getSimpleName() + " isn't loaded in the browser, "
-                        + elementName + " isn't visible.");
+                        + elementName + " with locator " + element.getLocator() + " isn't visible.");
             }
             break;
         case "isEnabled":
             if (!present || (present && !element.isEnabled())) {
                 throw new PageValidationException(getClass().getSimpleName() + " isn't loaded in the browser, "
-                        + elementName + " isn't enabled.");
+                        + elementName + " with locator " + element.getLocator() + " isn't enabled.");
             }
             break;
         default:
             if (!present) {
                 throw new PageValidationException(getClass().getSimpleName() + " isn't loaded in the browser, "
-                        + elementName + " isn't present.");
+                        + elementName + " with locator " + element.getLocator() + " isn't present.");
             }
             break;
         }


### PR DESCRIPTION
New stacktrace for click(Object):

```
Caused by: com.paypal.selion.platform.html.PageValidationException: TestPage isn't loaded in the browser, fieldXTextField with locator //input[@id='fieldXId'] isn't enabled.
    at com.paypal.selion.testcomponents.BasicPageImpl.verifyElementByAction(BasicPageImpl.java:202)
    at com.paypal.selion.testcomponents.BasicPageImpl.validatePage(BasicPageImpl.java:146)
    at com.paypal.selion.platform.html.AbstractElement$2.apply(AbstractElement.java:508)
    at com.paypal.selion.platform.html.AbstractElement$2.apply(AbstractElement.java:1)
    at org.openqa.selenium.support.ui.FluentWait.until(FluentWait.java:209)
    ... 26 more
```

New stacktrace for clickAndExpectOneOf(Object):

```
Caused by: com.paypal.selion.platform.html.ExpectOneOfException: 
    Object 1: TestPage
    PageValidationException: TestPage isn't loaded in the browser, fieldXTextField with locator //input[@id='fieldXId'] isn't enabled.
            at com.paypal.selion.testcomponents.BasicPageImpl.verifyElementByAction(BasicPageImpl.java:202)
    Object 2: TestPage
    PageValidationException: TestPage isn't loaded in the browser, fieldXTextField with locator //input[@id='fieldXId'] isn't enabled.
            at com.paypal.selion.testcomponents.BasicPageImpl.verifyElementByAction(BasicPageImpl.java:202)
    at com.paypal.selion.platform.html.AbstractElement$4.apply(AbstractElement.java:694)
    at com.paypal.selion.platform.html.AbstractElement$4.apply(AbstractElement.java:1)
    at org.openqa.selenium.support.ui.FluentWait.until(FluentWait.java:209)
    ... 26 more
```
