### PR TITLE
Fix #184 - SeLion Android elements are not custom elements

### DIFF
--- a/codegen/src/main/java/com/paypal/selion/elements/AndroidSeLionElementList.java
+++ b/codegen/src/main/java/com/paypal/selion/elements/AndroidSeLionElementList.java
@@ -22,54 +22,62 @@ import java.util.List;
 import com.paypal.selion.plugins.GUIObjectDetails;
 
 public class AndroidSeLionElementList extends AbstractSeLionElementList {
+    public static final String UIAUTOMATION_ELEMENT_CLASS = "com.paypal.selion.platform.mobile.android";
+
+    public static AndroidSeLionElementList UiButton =
+            new AndroidSeLionElementList(UIAUTOMATION_ELEMENT_CLASS, "UiButton", true);
+    public static AndroidSeLionElementList UiTextField =
+            new AndroidSeLionElementList(UIAUTOMATION_ELEMENT_CLASS, "UiTextField", true);
+    public static AndroidSeLionElementList UiObject =
+            new AndroidSeLionElementList(UIAUTOMATION_ELEMENT_CLASS, "UiObject", true);
+    public static AndroidSeLionElementList BASE_CLASS =
+            new AndroidSeLionElementList(null, "baseClass", false);
+
+    private static AndroidSeLionElementList[] values = { UiButton, UiTextField, UiObject, BASE_CLASS };
 
     protected AndroidSeLionElementList(String elementPackage, String element, boolean uiElement) {
         super(elementPackage, element, uiElement);
     }
 
     /**
-     * The android elements are added as custom elements and SeLion does not declare any elements specifically 
-     * which explains the empty array to hold the custom elements.
-     */
-    private static AndroidSeLionElementList[] values = {};
-    
-    /**
-     * By providing the qualified name of a custom element we can register it to the element array.
-     * Custom elements are inserted before SeLion elements, if you use the same name it will overwrite the existing element.
+     * By providing the qualified name of a custom element we can register it to the element array. Custom elements are
+     * inserted before SeLion elements, if you use the same name it will overwrite the existing element.
      * 
-     * @param element string of the qualified class
+     * @param element
+     *            string of the qualified class
      */
     public static void registerElement(String element) {
         List<AndroidSeLionElementList> temp = new ArrayList<AndroidSeLionElementList>(Arrays.asList(values));
-        
-        temp.add(0, new AndroidSeLionElementList(HtmlElementUtils.getPackage(element), HtmlElementUtils.getClass(element), true));
-        
+
+        temp.add(0, new AndroidSeLionElementList(HtmlElementUtils.getPackage(element), HtmlElementUtils.getClass(element),
+                        true));
+
         values = temp.toArray(new AndroidSeLionElementList[temp.size()]);
     }
-    
+
     /**
      * @param rawType
-     *            - The String using which an attempt to find a matching {@link AndroidSeLionElementList} is to be
+     *            The String using which an attempt to find a matching {@link AndroidSeLionElementList} is to be
      *            performed.
-     * @return - A {@link AndroidSeLionElementList} if the type ends with one of the values of {@link AndroidSeLionElementList}
-     *         that were passed as android elements (or) <code>null</code> if there were no matches.
+     * @return A {@link AndroidSeLionElementList} if the type ends with one of the values of
+     *         {@link AndroidSeLionElementList} that were passed as android elements (or) <code>null</code> if there
+     *         were no matches.
      */
     public static AndroidSeLionElementList findMatch(String rawType) {
         return (AndroidSeLionElementList) findMatch(values, rawType);
     }
-    
+
     /**
      * @param element
-     *            - The element that needs to be tested for being a valid {@link AndroidSeLionElementList} and whose
+     *            The element that needs to be tested for being a valid {@link AndroidSeLionElementList} and whose
      *            {@link AndroidSeLionElementList#isUIElement()} returns true.
-     * @return - <code>true</code> if there was a match and <code>false</code> otherwise.
+     * @return <code>true</code> if there was a match and <code>false</code> otherwise.
      */
     public static boolean isValidUIElement(String element) {
         return isValidUIElement(values, element);
 
     }
-    
-    
+
     public static List<GUIObjectDetails> getGUIObjectList(List<String> keys) {
         List<GUIObjectDetails> mobileObjectDetailsList = new ArrayList<GUIObjectDetails>();
 

--- a/codegen/src/main/java/com/paypal/selion/elements/IOSSeLionElementList.java
+++ b/codegen/src/main/java/com/paypal/selion/elements/IOSSeLionElementList.java
@@ -28,43 +28,57 @@ import com.paypal.selion.plugins.GUIObjectDetails;
 public class IOSSeLionElementList extends AbstractSeLionElementList {
     public static final String UIAUTOMATION_ELEMENT_CLASS = "com.paypal.selion.platform.mobile.ios";
 
-    public static IOSSeLionElementList UIAButton = new IOSSeLionElementList(UIAUTOMATION_ELEMENT_CLASS, "UIAButton", true);
-    public static IOSSeLionElementList UIAAlert = new IOSSeLionElementList(UIAUTOMATION_ELEMENT_CLASS, "UIAAlert", true);
-    public static IOSSeLionElementList UIANavigationBar = new IOSSeLionElementList(UIAUTOMATION_ELEMENT_CLASS, "UIANavigationBar", true);
-    public static IOSSeLionElementList UIAPicker = new IOSSeLionElementList(UIAUTOMATION_ELEMENT_CLASS, "UIAPicker", true);
-    public static IOSSeLionElementList UIASlider = new IOSSeLionElementList(UIAUTOMATION_ELEMENT_CLASS, "UIASlider", true);
-    public static IOSSeLionElementList UIAStaticText = new IOSSeLionElementList(UIAUTOMATION_ELEMENT_CLASS, "UIAStaticText", true);
-    public static IOSSeLionElementList UIASwitch = new IOSSeLionElementList(UIAUTOMATION_ELEMENT_CLASS, "UIASwitch", true);
-    public static IOSSeLionElementList UIATableView = new IOSSeLionElementList(UIAUTOMATION_ELEMENT_CLASS, "UIATableView", true);
-    public static IOSSeLionElementList UIATextField = new IOSSeLionElementList(UIAUTOMATION_ELEMENT_CLASS, "UIATextField", true);
-    public static IOSSeLionElementList BASE_CLASS = new IOSSeLionElementList(null, "baseClass", false);
+    public static IOSSeLionElementList UIAButton =
+            new IOSSeLionElementList(UIAUTOMATION_ELEMENT_CLASS, "UIAButton", true);
+    public static IOSSeLionElementList UIAAlert =
+            new IOSSeLionElementList(UIAUTOMATION_ELEMENT_CLASS, "UIAAlert", true);
+    public static IOSSeLionElementList UIANavigationBar =
+            new IOSSeLionElementList(UIAUTOMATION_ELEMENT_CLASS, "UIANavigationBar", true);
+    public static IOSSeLionElementList UIAPicker =
+            new IOSSeLionElementList(UIAUTOMATION_ELEMENT_CLASS, "UIAPicker", true);
+    public static IOSSeLionElementList UIASlider =
+            new IOSSeLionElementList(UIAUTOMATION_ELEMENT_CLASS, "UIASlider", true);
+    public static IOSSeLionElementList UIAStaticText =
+            new IOSSeLionElementList(UIAUTOMATION_ELEMENT_CLASS, "UIAStaticText", true);
+    public static IOSSeLionElementList UIASwitch =
+            new IOSSeLionElementList(UIAUTOMATION_ELEMENT_CLASS, "UIASwitch", true);
+    public static IOSSeLionElementList UIATableView =
+            new IOSSeLionElementList(UIAUTOMATION_ELEMENT_CLASS, "UIATableView", true);
+    public static IOSSeLionElementList UIATextField =
+            new IOSSeLionElementList(UIAUTOMATION_ELEMENT_CLASS, "UIATextField", true);
+    public static IOSSeLionElementList UIAElement =
+            new IOSSeLionElementList(UIAUTOMATION_ELEMENT_CLASS, "UIAElement", true);
+    public static IOSSeLionElementList BASE_CLASS =
+            new IOSSeLionElementList(null, "baseClass", false);
 
     private static IOSSeLionElementList[] values = { UIAButton, UIAAlert, UIANavigationBar, UIAPicker, UIASlider,
-            UIAStaticText, UIASwitch, UIATableView, UIATextField, BASE_CLASS };
+            UIAStaticText, UIASwitch, UIATableView, UIATextField, UIAElement, BASE_CLASS };
 
     private IOSSeLionElementList(String elementPackage, String element, boolean isHtmlType) {
         super(elementPackage, element, isHtmlType);
     }
-    
+
     /**
-     * By providing the qualified name of a custom element we can register it to the element array.
-     * Custom elements are inserted before SeLion elements, if you use the same name it will overwrite the existing element.
+     * By providing the qualified name of a custom element we can register it to the element array. Custom elements are
+     * inserted before SeLion elements, if you use the same name it will overwrite the existing element.
      * 
-     * @param element string of the qualified class
+     * @param element
+     *            string of the qualified class
      */
     public static void registerElement(String element) {
         List<IOSSeLionElementList> temp = new ArrayList<IOSSeLionElementList>(Arrays.asList(values));
-        
-        temp.add(0, new IOSSeLionElementList(HtmlElementUtils.getPackage(element), HtmlElementUtils.getClass(element), true));
-        
+
+        temp.add(0, new IOSSeLionElementList(HtmlElementUtils.getPackage(element), HtmlElementUtils.getClass(element),
+                true));
+
         values = temp.toArray(new IOSSeLionElementList[temp.size()]);
     }
 
     /**
      * @param rawType
      *            The String using which an attempt to find a matching {@link IOSSeLionElementList} is to be performed.
-     * @return A {@link IOSSeLionElementList} if the type ends with one of the values of {@link IOSSeLionElementList} enum (or)
-     *         <code>null</code> if there were no matches.
+     * @return A {@link IOSSeLionElementList} if the type ends with one of the values of {@link IOSSeLionElementList}
+     *         enum (or) <code>null</code> if there were no matches.
      */
     public static IOSSeLionElementList findMatch(String rawType) {
         return (IOSSeLionElementList) findMatch(values, rawType);
@@ -78,9 +92,10 @@ public class IOSSeLionElementList extends AbstractSeLionElementList {
     public static boolean isValid(String element) {
         return isValid(values, element);
     }
-    
+
     /**
-     * @param element The element that needs to be searched.
+     * @param element
+     *            The element that needs to be searched.
      * @return <code>true</code> if the element was found in the set of elements provided.
      */
     public static boolean isExactMatch(String element) {


### PR DESCRIPTION
- Added SeLion default Android elements (UiObject, UiTextView, UiButton)
  to AndroidSeLionElementList of codegen. Previously, they were treated
  as custom elements.. which should not have been the case
- Also added UIAElement to IOSSelionElementList
- Misc formatting changes
