### PR TITLE
Add ability for mobile elements to pass a WebPage to methods which follow our "click(Object ... expected)" pattern

### DIFF
--- a/archetype/src/main/resources/archetype-resources/src/main/resources/GUIData/sample/MyAppHomePage.yaml
+++ b/archetype/src/main/resources/archetype-resources/src/main/resources/GUIData/sample/MyAppHomePage.yaml
@@ -1,31 +1,31 @@
 baseClass: "com.paypal.selion.testcomponents.BasicPageImpl"
 pageTitle:
-    english: "Awesome Deals"
+    US: "Awesome Deals"
 elements:
     firstNameTextField:
         locators:
-            english: "first_name"
+            US: "first_name"
     lastNameTextField:
         locators:
-            english: "last_name"
+            US: "last_name"
     emailTextField:
         locators:
-            english: "email"
+            US: "email"
     submitButton:
         locators:
-            english: "submit_button"
+            US: "submit_button"
     firstNameLabel:
         locators:
-            english: "display_first_name"
+            US: "display_first_name"
     lastNameLabel:
         locators:
-            english: "display_last_name"
+            US: "display_last_name"
     emailLabel:
         locators:
-            english: "display_email"
+            US: "display_email"
     retryAgainButton:
         locators:
-            english: "retry_button"
+            US: "retry_button"
 pageValidators: [
     firstNameLabel,
     lastNameLabel,

--- a/archetype/src/main/resources/archetype-resources/src/main/resources/GUIData/sample/NativeAppTestPage.yaml
+++ b/archetype/src/main/resources/archetype-resources/src/main/resources/GUIData/sample/NativeAppTestPage.yaml
@@ -3,11 +3,11 @@ defaultLocale: "US"
 elements:
   sampleUIANavigationBar:
     locators:
-      english: "//UIAApplication[1]/UIAWindow[2]/UIANavigationBar[1]"
+      US: "//UIAApplication[1]/UIAWindow[2]/UIANavigationBar[1]"
   sampleUIATableView:
     locators:
-      english: "//UIAApplication[1]/UIAWindow[2]/UIATableView[1]"
+      US: "//UIAApplication[1]/UIAWindow[2]/UIATableView[1]"
   sampleUIAStaticText:
     locators:
-      english: "//UIAApplication[1]/UIAWindow[2]/UIAStaticText[1]"
+      US: "//UIAApplication[1]/UIAWindow[2]/UIAStaticText[1]"
 platform: "ios"

--- a/archetype/src/main/resources/archetype-resources/src/test/java/sample/selion/NativeAppFlowUsingSeLionPageObject.java
+++ b/archetype/src/main/resources/archetype-resources/src/test/java/sample/selion/NativeAppFlowUsingSeLionPageObject.java
@@ -40,7 +40,7 @@ public class NativeAppFlowUsingSeLionPageObject {
         // -DSELION_SITE_LOCALE=<locale_value>
         // 3. We can set this at a specific <test> level by setting the parameter
         // <parameter name="siteLocale" value="locale_value_to_be_set"/> in the suite xml file.
-        NativeAppTestPage samplePage = new NativeAppTestPage("english");
+        NativeAppTestPage samplePage = new NativeAppTestPage("US");
         
         //The NativeAppTestPage.java gets its data from NativeAppTestPage.yaml"
 

--- a/archetype/src/main/resources/archetype-resources/src/test/java/sample/selion/UIFlowUsingSeLionPageObjectsTest.java
+++ b/archetype/src/main/resources/archetype-resources/src/test/java/sample/selion/UIFlowUsingSeLionPageObjectsTest.java
@@ -52,7 +52,7 @@ public class UIFlowUsingSeLionPageObjectsTest {
         //-DSELION_SITE_LOCALE=english
         //3. We can set this at a specific <test> level by setting the parameter
         //<parameter name="siteLocale" value="english"/> in the suite xml file.
-        MyAppHomePage page = new MyAppHomePage("english");
+        MyAppHomePage page = new MyAppHomePage("US");
         page.getFirstNameTextField().type("Joe");
         page.getLastNameTextField().type("User");
         page.getEmailTextField().type("joeuser@foo.bar");

--- a/client/src/main/java/com/paypal/selion/platform/html/WebPage.java
+++ b/client/src/main/java/com/paypal/selion/platform/html/WebPage.java
@@ -1,5 +1,5 @@
 /*-------------------------------------------------------------------------------------------------------------------*\
-|  Copyright (C) 2014 PayPal                                                                                          |
+|  Copyright (C) 2014-2015 PayPal                                                                                     |
 |                                                                                                                     |
 |  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
 |  with the License.                                                                                                  |
@@ -15,8 +15,13 @@
 
 package com.paypal.selion.platform.html;
 
+import com.paypal.selion.testcomponents.BasicPageImpl;
+
 /**
- * A generic interface for Web Page Objects in SeLion.
+ * A generic interface for web Page Objects in SeLion.<br>
+ * <br>
+ * Note: "web" is used loosely here. This interface can also be implemented to support mobile applications as is the
+ * case with {@link BasicPageImpl}
  * 
  */
 public interface WebPage {
@@ -61,15 +66,19 @@ public interface WebPage {
     WebPage getPage();
 
     /**
-     * Validates if the page is loaded in the browser
+     * Validates the page against the defined <code>pageValidators</code> defined in the PageYAML for this page.
+     * 
+     * @throws PageValidationException
+     *             when the page does not validate.
      */
     void validatePage();
 
     /**
-     * Returns if page is opened in the browser. Use {@link WebPage#validatePage()} if you want to validate if a page is
-     * loaded.
+     * Return a boolean result based on the outcome of calling {@link WebPage#validatePage()} to validate the loaded
+     * page on the WebDriver session.
      * 
-     * @return if page is opened
+     * @return <code>true</code> or <code>false</code>, if the page is validated, meaning all
+     *         <code>pageValidators</code> pass
      */
-    boolean isCurrentPageInBrowser();
+    boolean isPageValidated();
 }

--- a/client/src/main/java/com/paypal/selion/platform/mobile/android/UiObject.java
+++ b/client/src/main/java/com/paypal/selion/platform/mobile/android/UiObject.java
@@ -19,10 +19,9 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
-import com.paypal.selion.configuration.Config.ConfigProperty;
-import com.paypal.selion.configuration.ConfigManager;
 import com.paypal.selion.logger.SeLionLogger;
 import com.paypal.selion.platform.grid.Grid;
+import com.paypal.selion.platform.html.WebPage;
 import com.paypal.selion.platform.html.support.HtmlElementUtils;
 import com.paypal.selion.platform.utilities.WebDriverWaitUtils;
 import com.paypal.test.utilities.logging.SimpleLogger;
@@ -296,10 +295,13 @@ public class UiObject implements UserinterfaceObject {
                 continue;
             }
             if (expect instanceof ExpectedCondition<?>) {
-                WebDriverWait wait = new WebDriverWait(Grid.driver(),
-                        Long.valueOf(ConfigManager.getConfig(Grid.getTestSession().getXmlTestName()).getConfigProperty(
-                                ConfigProperty.EXECUTION_TIMEOUT)) / 1000);
+                long timeOutInSeconds = Grid.getExecutionTimeoutValue() / 1000;
+                WebDriverWait wait = new WebDriverWait(Grid.driver(), timeOutInSeconds);
                 wait.until(ExpectedCondition.class.cast(expect));
+                continue;
+            }
+            if (expect instanceof WebPage) {
+                WebDriverWaitUtils.waitUntilWebPageIsValidated((WebPage) expect);
                 continue;
             }
         }

--- a/client/src/main/java/com/paypal/selion/platform/mobile/android/UserinterfaceObject.java
+++ b/client/src/main/java/com/paypal/selion/platform/mobile/android/UserinterfaceObject.java
@@ -17,6 +17,8 @@ package com.paypal.selion.platform.mobile.android;
 
 import org.openqa.selenium.support.ui.ExpectedCondition;
 
+import com.paypal.selion.platform.html.WebPage;
+
 /**
  * <code>UserinterfaceObject</code> exposes the base interactions that can be carried on any Android UI automation
  * element. This class makes some minor changes to the methods exposed by UiObject of Android UiAutomator framework.
@@ -35,8 +37,8 @@ public interface UserinterfaceObject {
      * Performs a click at the center of the visible bounds of the UI element represented by this UiObject.
      * 
      * @param expected
-     *            Expected entities in the form of objects extending {@link UiObject} or xpath location in the form of
-     *            {@link String} or instances of {@link ExpectedCondition}.
+     *            Expected entities in the form of objects extending {@link UiObject}, xpath location in the form of
+     *            {@link String}, instances of {@link ExpectedCondition}, or an instance of a {@link WebPage}
      */
     void click(Object... expected);
 
@@ -44,8 +46,8 @@ public interface UserinterfaceObject {
      * Clicks the bottom and right corner of the UI element.
      * 
      * @param expected
-     *            Expected entities in the form of objects extending {@link UiObject} or xpath location in the form of
-     *            {@link String} or instances of {@link ExpectedCondition}.
+     *            Expected entities in the form of objects extending {@link UiObject}, xpath location in the form of
+     *            {@link String}, instances of {@link ExpectedCondition}, or an instance of a {@link WebPage}
      */
     void clickBottomRight(Object... expected);
 
@@ -53,8 +55,8 @@ public interface UserinterfaceObject {
      * Clicks the top and left corner of the UI element.
      * 
      * @param expected
-     *            Expected entities in the form of objects extending {@link UiObject} or xpath location in the form of
-     *            {@link String} or instances of {@link ExpectedCondition}.
+     *            Expected entities in the form of objects extending {@link UiObject}, xpath location in the form of
+     *            {@link String}, instances of {@link ExpectedCondition}, or an instance of a {@link WebPage}
      */
     void clickTopLeft(Object... expected);
 
@@ -135,8 +137,8 @@ public interface UserinterfaceObject {
      * Long clicks the center of the visible bounds of the UI element.
      * 
      * @param expected
-     *            Expected entities in the form of objects extending {@link UiObject} or xpath location in the form of
-     *            {@link String} or instances of {@link ExpectedCondition}.
+     *            Expected entities in the form of objects extending {@link UiObject}, xpath location in the form of
+     *            {@link String}, instances of {@link ExpectedCondition}, or an instance of a {@link WebPage}
      */
     void longClick(Object... expected);
 
@@ -144,8 +146,8 @@ public interface UserinterfaceObject {
      * Long clicks bottom and right corner of the UI element.
      * 
      * @param expected
-     *            Expected entities in the form of objects extending {@link UiObject} or xpath location in the form of
-     *            {@link String} or instances of {@link ExpectedCondition}.
+     *            Expected entities in the form of objects extending {@link UiObject}, xpath location in the form of
+     *            {@link String}, instances of {@link ExpectedCondition}, or an instance of a {@link WebPage}
      */
     void longClickBottomRight(Object... expected);
 
@@ -153,8 +155,8 @@ public interface UserinterfaceObject {
      * Long clicks on the top and left corner of the UI element.
      * 
      * @param expected
-     *            Expected entities in the form of objects extending {@link UiObject} or xpath location in the form of
-     *            {@link String} or instances of {@link ExpectedCondition}.
+     *            Expected entities in the form of objects extending {@link UiObject}, xpath location in the form of
+     *            {@link String}, instances of {@link ExpectedCondition}, or an instance of a {@link WebPage}
      */
     void longClickTopLeft(Object... expected);
 
@@ -171,8 +173,8 @@ public interface UserinterfaceObject {
      * UI element does not need to be scrollable.
      * 
      * @param expected
-     *            Expected entities in the form of objects extending {@link UiObject} or xpath location in the form of
-     *            {@link String} or instances of {@link ExpectedCondition}.
+     *            Expected entities in the form of objects extending {@link UiObject}, xpath location in the form of
+     *            {@link String}, instances of {@link ExpectedCondition}, or an instance of a {@link WebPage}
      */
     void swipeLeft(Object... expected);
 
@@ -181,8 +183,8 @@ public interface UserinterfaceObject {
      * targeted UI element does not need to be scrollable.
      * 
      * @param expected
-     *            Expected entities in the form of objects extending {@link UiObject} or xpath location in the form of
-     *            {@link String} or instances of {@link ExpectedCondition}.
+     *            Expected entities in the form of objects extending {@link UiObject}, xpath location in the form of
+     *            {@link String}, instances of {@link ExpectedCondition}, or an instance of a {@link WebPage}
      */
     void swipeRight(Object... expected);
 
@@ -191,8 +193,8 @@ public interface UserinterfaceObject {
      * UI element does not need to be scrollable.
      * 
      * @param expected
-     *            Expected entities in the form of objects extending {@link UiObject} or xpath location in the form of
-     *            {@link String} or instances of {@link ExpectedCondition}.
+     *            Expected entities in the form of objects extending {@link UiObject}, xpath location in the form of
+     *            {@link String}, instances of {@link ExpectedCondition}, or an instance of a {@link WebPage}
      */
     void swipeUp(Object... expected);
 
@@ -201,8 +203,8 @@ public interface UserinterfaceObject {
      * UI element does not need to be scrollable.
      * 
      * @param expected
-     *            Expected entities in the form of objects extending {@link UiObject} or xpath location in the form of
-     *            {@link String} or instances of {@link ExpectedCondition}.
+     *            Expected entities in the form of objects extending {@link UiObject}, xpath location in the form of
+     *            {@link String}, instances of {@link ExpectedCondition}, or an instance of a {@link WebPage}
      */
     void swipeDown(Object... expected);
 

--- a/client/src/main/java/com/paypal/selion/platform/mobile/ios/UIAElement.java
+++ b/client/src/main/java/com/paypal/selion/platform/mobile/ios/UIAElement.java
@@ -23,10 +23,9 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
-import com.paypal.selion.configuration.Config.ConfigProperty;
-import com.paypal.selion.configuration.ConfigManager;
 import com.paypal.selion.logger.SeLionLogger;
 import com.paypal.selion.platform.grid.Grid;
+import com.paypal.selion.platform.html.WebPage;
 import com.paypal.selion.platform.html.support.HtmlElementUtils;
 import com.paypal.selion.platform.utilities.WebDriverWaitUtils;
 import com.paypal.test.utilities.logging.SimpleLogger;
@@ -166,10 +165,13 @@ public class UIAElement implements UIAutomationElement {
                 continue;
             }
             if (expect instanceof ExpectedCondition<?>) {
-                WebDriverWait wait = new WebDriverWait(Grid.driver(),
-                        Long.valueOf(ConfigManager.getConfig(Grid.getTestSession().getXmlTestName()).getConfigProperty(
-                                ConfigProperty.EXECUTION_TIMEOUT)) / 1000);
+                long timeOutInSeconds = Grid.getExecutionTimeoutValue() / 1000;
+                WebDriverWait wait = new WebDriverWait(Grid.driver(), timeOutInSeconds);
                 wait.until(ExpectedCondition.class.cast(expect));
+                continue;
+            }
+            if (expect instanceof WebPage) {
+                WebDriverWaitUtils.waitUntilWebPageIsValidated((WebPage) expect);
                 continue;
             }
         }

--- a/client/src/main/java/com/paypal/selion/platform/mobile/ios/UIAutomationElement.java
+++ b/client/src/main/java/com/paypal/selion/platform/mobile/ios/UIAutomationElement.java
@@ -22,6 +22,8 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.RemoteWebElement;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 
+import com.paypal.selion.platform.html.WebPage;
+
 /**
  * <code> UIAutomationElement </code> is the super interface for all user interface elements in the context of the
  * Automation instrument for automating user interface testing of iOS apps. This interface defines more general methods
@@ -43,8 +45,8 @@ public interface UIAutomationElement {
      * Double-taps the specified element.
      * 
      * @param expected
-     *            Expected entities in the form of objects extending {@link UIAElement} or xpath location in the form of
-     *            {@link String} or instances of {@link ExpectedCondition}.
+     *            Expected entities in the form of objects extending {@link UIAElement}, xpath location in the form of
+     *            {@link String}, instances of {@link ExpectedCondition}, or an instance of a {@link WebPage}
      */
     void doubleTap(Object... expected);
 
@@ -57,8 +59,8 @@ public interface UIAutomationElement {
      * Taps the specified element and optionally waits for the provided expected elements.
      * 
      * @param expected
-     *            Expected entities in the form of objects extending {@link UIAElement} or xpath location in the form of
-     *            {@link String} or instances of {@link ExpectedCondition}.
+     *            Expected entities in the form of objects extending {@link UIAElement}, xpath location in the form of
+     *            {@link String}, instances of {@link ExpectedCondition}, or an instance of a {@link WebPage}
      */
     void tap(Object... expected);
 
@@ -69,8 +71,8 @@ public interface UIAutomationElement {
      * @param gestureOptions
      *            {@link EnumMap} specifying the gesture attributes.
      * @param expected
-     *            Expected entities in the form of objects extending {@link UIAElement} or xpath location in the form of
-     *            {@link String} or instances of {@link ExpectedCondition}.
+     *            Expected entities in the form of objects extending {@link UIAElement}, xpath location in the form of
+     *            {@link String}, instances of {@link ExpectedCondition}, or an instance of a {@link WebPage}
      */
     void tapWithOptions(EnumMap<GestureOptions, String> gestureOptions, Object... expected);
 
@@ -78,8 +80,8 @@ public interface UIAutomationElement {
      * Performs a two-finger (two-touch) tap on this element.
      * 
      * @param expected
-     *            Expected entities in the form of objects extending {@link UIAElement} or xpath location in the form of
-     *            {@link String} or instances of {@link ExpectedCondition}.
+     *            Expected entities in the form of objects extending {@link UIAElement}, xpath location in the form of
+     *            {@link String}, instances of {@link ExpectedCondition}, or an instance of a {@link WebPage}
      */
     void twoFingerTap(Object... expected);
 

--- a/client/src/main/java/com/paypal/selion/platform/utilities/WebDriverWaitUtils.java
+++ b/client/src/main/java/com/paypal/selion/platform/utilities/WebDriverWaitUtils.java
@@ -1,5 +1,5 @@
 /*-------------------------------------------------------------------------------------------------------------------*\
-|  Copyright (C) 2014-15 PayPal                                                                                       |
+ |  Copyright (C) 2014-15 PayPal                                                                                       |
 |                                                                                                                     |
 |  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
 |  with the License.                                                                                                  |
@@ -28,6 +28,7 @@ import org.openqa.selenium.support.ui.WebDriverWait;
 import com.google.common.base.Preconditions;
 import com.paypal.selion.logger.SeLionLogger;
 import com.paypal.selion.platform.grid.Grid;
+import com.paypal.selion.platform.html.WebPage;
 import com.paypal.selion.platform.html.support.HtmlElementUtils;
 import com.paypal.test.utilities.logging.SimpleLogger;
 
@@ -36,23 +37,23 @@ import com.paypal.test.utilities.logging.SimpleLogger;
  *
  */
 public final class WebDriverWaitUtils {
-    
+
     private final static SimpleLogger logger = SeLionLogger.getLogger();
 
-    private WebDriverWaitUtils(){
-        //Utility class. So hide the constructor to defeat instantiation
+    private WebDriverWaitUtils() {
+        // Utility class. So hide the constructor to defeat instantiation
     }
 
-    private static String getTextFromBody(){
+    private static String getTextFromBody() {
         WebElement bodyTag = Grid.driver().findElement(By.tagName("body"));
         return bodyTag.getText();
     }
 
-    private static void waitForCondition(ExpectedCondition<?> condition){
+    private static void waitForCondition(ExpectedCondition<?> condition) {
         waitForCondition(condition, timeoutInSeconds());
     }
-    
-    private static void waitForCondition(ExpectedCondition<?> condition, long timeoutInSeconds){
+
+    private static void waitForCondition(ExpectedCondition<?> condition, long timeoutInSeconds) {
         new WebDriverWait(Grid.driver(), timeoutInSeconds).until(condition);
     }
 
@@ -83,7 +84,7 @@ public final class WebDriverWaitUtils {
         waitForCondition(condition);
         logger.exiting();
     }
-    
+
     /**
      * Waits until element element is present on the DOM of a page. This does not necessarily mean that the element is
      * visible.
@@ -98,7 +99,7 @@ public final class WebDriverWaitUtils {
         waitForCondition(condition);
         logger.exiting();
     }
-    
+
     /**
      * Waits until element is present on the DOM of a page and visible. Visibility means that the element is not only
      * displayed but also has a height and width that is greater than 0.
@@ -113,7 +114,7 @@ public final class WebDriverWaitUtils {
         waitForCondition(condition);
         logger.exiting();
     }
-    
+
     /**
      * Waits until the current page's title contains a case-sensitive substring of the given title.
      * 
@@ -122,12 +123,13 @@ public final class WebDriverWaitUtils {
      */
     public static void waitUntilPageTitleContains(final String pageTitle) {
         logger.entering(pageTitle);
-        Preconditions.checkArgument(StringUtils.isNotEmpty(pageTitle), "Expected Page title cannot be null (or) empty.");
+        Preconditions
+                .checkArgument(StringUtils.isNotEmpty(pageTitle), "Expected Page title cannot be null (or) empty.");
         ExpectedCondition<Boolean> condition = ExpectedConditions.titleContains(pageTitle);
         waitForCondition(condition);
         logger.exiting();
     }
-    
+
     /**
      * Waits until text appears anywhere within the current page's &lt;body&gt; tag.
      *
@@ -146,25 +148,46 @@ public final class WebDriverWaitUtils {
         waitForCondition(conditionToCheck);
         logger.exiting();
     }
-    
+
     /**
-     * Waits until both two elements appear at the page
-     * Waits until all the elements are present on the DOM of a page. 
+     * Waits until both two elements appear at the page Waits until all the elements are present on the DOM of a page.
      * This does not necessarily mean that the element is visible.
      *
-     * @param locators - An array of strings that represents the list of elements to check.
-     *            
+     * @param locators
+     *            an array of strings that represents the list of elements to check.
+     * 
      */
     public static void waitUntilAllElementsArePresent(final String... locators) {
         logger.entering(new Object[] { Arrays.toString(locators) });
         Preconditions.checkArgument(locators != null, "Please provide a valid set of locators.");
-        for (String eachLocator : locators){
+        for (String eachLocator : locators) {
             waitUntilElementIsPresent(eachLocator);
         }
         logger.exiting();
     }
 
-    private static long timeoutInSeconds(){
-        return Grid.getExecutionTimeoutValue()/1000;
+    /**
+     * Waits until all <code>pageValidators</code> for a given object pass. The {@link WebPage} instance must express
+     * something that validates the page or calling this will cause a wait timeout.
+     * 
+     * @param pageObject
+     *            a {@link WebPage} instance.
+     */
+    public static void waitUntilWebPageIsValidated(WebPage pageObject) {
+        logger.entering(pageObject);
+        Preconditions.checkArgument(pageObject != null, "Please provide a valid instance of WebPage.");
+        final WebPage w = (WebPage) pageObject;
+        ExpectedCondition<Boolean> conditionToCheck = new ExpectedCondition<Boolean>() {
+            @Override
+            public Boolean apply(WebDriver webDriver) {
+                return w.isPageValidated();
+            }
+        };
+        waitForCondition(conditionToCheck);
+        logger.exiting();
+    }
+
+    private static long timeoutInSeconds() {
+        return Grid.getExecutionTimeoutValue() / 1000;
     }
 }

--- a/client/src/main/java/com/paypal/selion/testcomponents/AbstractPage.java
+++ b/client/src/main/java/com/paypal/selion/testcomponents/AbstractPage.java
@@ -197,7 +197,7 @@ public abstract class AbstractPage implements WebPage {
     }
 
     @Override
-    public boolean isCurrentPageInBrowser() {
+    public boolean isPageValidated() {
         throw new UnsupportedOperationException("This operation is NOT supported.");
     }
 

--- a/client/src/main/java/com/paypal/selion/testcomponents/BasicPageImpl.java
+++ b/client/src/main/java/com/paypal/selion/testcomponents/BasicPageImpl.java
@@ -120,10 +120,6 @@ public abstract class BasicPageImpl extends AbstractPage implements ParentTraits
         return this;
     }
 
-    /**
-     * Perform page validations against list of elements defined in the YAML file.
-     */
-    // Call getPage to make sure the page is initialized.
     public void validatePage() {
         getObjectMap();
 
@@ -149,7 +145,7 @@ public abstract class BasicPageImpl extends AbstractPage implements ParentTraits
     }
 
     /**
-     * Get the AbstractElement by the key that is defined in the Yaml files.
+     * Get the AbstractElement by the key that is defined in the PageYAML files.
      * 
      * @param elementName
      *            The element name
@@ -174,7 +170,7 @@ public abstract class BasicPageImpl extends AbstractPage implements ParentTraits
     }
 
     /**
-     * Verify if the element is availible based on a certain action
+     * Verify if the element is available based on a certain action
      * 
      * @param elementName
      * @param action
@@ -212,12 +208,12 @@ public abstract class BasicPageImpl extends AbstractPage implements ParentTraits
         }
     }
 
-    /**
-     * Verify's if the current page is opened in the browser. It does this based on the pageValidators.
+    /*
+     * (non-Javadoc)
      * 
-     * @return boolean if page is opened.
+     * @see com.paypal.selion.platform.html.WebPage#isPageValidated()
      */
-    public boolean isCurrentPageInBrowser() {
+    public boolean isPageValidated() {
         try {
             validatePage();
             return true;

--- a/client/src/test/java/com/paypal/selion/platform/grid/SeLionSeleniumTest.java
+++ b/client/src/test/java/com/paypal/selion/platform/grid/SeLionSeleniumTest.java
@@ -19,43 +19,43 @@ import com.paypal.selion.annotations.WebTest;
 import com.paypal.selion.configuration.Config;
 import com.paypal.selion.platform.html.Button;
 import com.paypal.selion.platform.utilities.WebDriverWaitUtils;
+import com.paypal.selion.testcomponents.BasicPageImpl;
 
 import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.Test;
 
-
 public class SeLionSeleniumTest {
 
     final String badLocator = "//wrong locator or text or page title";
-    final String locator = "//input[@id='gbqfq']";
-    final String pipedLocator = "//input[@id='gbqfq']|SomeOtherLocator";
+    final String locator = "//input[@id='lst-ib']";
+    final String pipedLocator = "//input[@id='lst-ib']|SomeOtherLocator";
     final String disappearElement = "btnI";
     final String pageTitle = "Google";
     final String text = "Gmail";
     final String url = "http://www.google.com";
 
-    @Test(groups = {"browser-tests"})
+    @Test(groups = { "browser-tests" })
     @WebTest
     public void testWaitUntilPageTitlePresentPos() {
         Grid.driver().get(url);
         WebDriverWaitUtils.waitUntilPageTitleContains(pageTitle);
     }
 
-    @Test(groups = {"browser-tests"})
+    @Test(groups = { "browser-tests" })
     @WebTest
     public void testWaitUntilElementVisiblePos() {
         Grid.driver().get(url);
         WebDriverWaitUtils.waitUntilElementIsVisible(locator);
     }
 
-    @Test(groups = {"browser-tests"})
+    @Test(groups = { "browser-tests" })
     @WebTest
     public void testWaitUntilTextPresentPos() {
         Grid.driver().get(url);
         WebDriverWaitUtils.waitUntilTextPresent(text);
     }
 
-    @Test(groups = {"browser-tests"})
+    @Test(groups = { "browser-tests" })
     @WebTest
     public void testWaitUntilElementDisapearPos() {
         Grid.driver().get(url);
@@ -65,21 +65,39 @@ public class SeLionSeleniumTest {
         WebDriverWaitUtils.waitUntilElementIsInvisible(disappearElement);
     }
 
-    @Test(groups = {"browser-tests"})
+    @Test(groups = { "browser-tests" })
     @WebTest
     public void testWaitUntilElementPresentPos() {
         Grid.driver().get(url);
         WebDriverWaitUtils.waitUntilElementIsPresent(locator);
     }
 
-    @Test(groups = {"browser-tests"})
+    @Test(groups = { "browser-tests" })
     @WebTest
     public void testWasitUntilElementPipedLocator() {
         Grid.driver().get(url);
         WebDriverWaitUtils.waitUntilElementIsPresent(pipedLocator);
     }
 
-    @Test(groups = {"browser-tests"}, expectedExceptions = {TimeoutException.class})
+    @Test(groups = { "browser-tests" }, expectedExceptions = { TimeoutException.class })
+    @WebTest
+    public void testWaitUntilWebPageIsValidatedNeg() {
+        String origTimeout = Config.getConfigProperty(Config.ConfigProperty.EXECUTION_TIMEOUT);
+        try {
+            Config.setConfigProperty(Config.ConfigProperty.EXECUTION_TIMEOUT, "20000");
+            Grid.driver().get(url);
+            WebDriverWaitUtils.waitUntilWebPageIsValidated(new BasicPageImpl() {
+                @Override
+                public BasicPageImpl getPage() {
+                    return this;
+                }
+            });
+        } finally {
+            Config.setConfigProperty(Config.ConfigProperty.EXECUTION_TIMEOUT, origTimeout);
+        }
+    }
+
+    @Test(groups = { "browser-tests" }, expectedExceptions = { TimeoutException.class })
     @WebTest
     public void testWaitUntilPageTitlePresentNeg() {
         String origTimeout = Config.getConfigProperty(Config.ConfigProperty.EXECUTION_TIMEOUT);
@@ -92,7 +110,7 @@ public class SeLionSeleniumTest {
         }
     }
 
-    @Test(groups = {"browser-tests"}, expectedExceptions = {TimeoutException.class})
+    @Test(groups = { "browser-tests" }, expectedExceptions = { TimeoutException.class })
     @WebTest
     public void testWaitUntilElementVisibleNeg() {
         String origTimeout = Config.getConfigProperty(Config.ConfigProperty.EXECUTION_TIMEOUT);
@@ -105,7 +123,7 @@ public class SeLionSeleniumTest {
         }
     }
 
-    @Test(groups = {"browser-tests"}, expectedExceptions = {TimeoutException.class})
+    @Test(groups = { "browser-tests" }, expectedExceptions = { TimeoutException.class })
     @WebTest
     public void testWaitUntilTextPresentNeg() {
         Grid.driver().get(url);
@@ -118,7 +136,7 @@ public class SeLionSeleniumTest {
         }
     }
 
-    @Test(groups = {"browser-tests"}, expectedExceptions = {RuntimeException.class})
+    @Test(groups = { "browser-tests" }, expectedExceptions = { RuntimeException.class })
     @WebTest
     public void testWaitUntilElementDisapearNeg() {
         String origTimeout = Config.getConfigProperty(Config.ConfigProperty.EXECUTION_TIMEOUT);
@@ -131,7 +149,7 @@ public class SeLionSeleniumTest {
         }
     }
 
-    @Test(groups = {"browser-tests"}, expectedExceptions = {TimeoutException.class})
+    @Test(groups = { "browser-tests" }, expectedExceptions = { TimeoutException.class })
     @WebTest
     public void testWaitUntilElementPresentNeg() {
         Grid.driver().get(url);

--- a/client/src/test/java/com/paypal/selion/testcomponents/BasicPageImplTest.java
+++ b/client/src/test/java/com/paypal/selion/testcomponents/BasicPageImplTest.java
@@ -26,6 +26,7 @@ import com.paypal.selion.annotations.WebTest;
 import com.paypal.selion.platform.asserts.SeLionAsserts;
 import com.paypal.selion.platform.grid.Grid;
 import com.paypal.selion.platform.html.Container;
+import com.paypal.selion.platform.utilities.WebDriverWaitUtils;
 import com.paypal.selion.testcomponents.BasicPageImpl;
 
 public class BasicPageImplTest {
@@ -52,6 +53,20 @@ public class BasicPageImplTest {
                 "Button value retrieved successfully");
 
         SeLionAsserts.assertFalse(page.getHiddenButton().isVisible(), "Yaml Hidden button is actually hidden");
+    }
+
+    @Test(groups = { "functional" })
+    @WebTest
+    public void testWebPageIsValidated() throws InterruptedException, IOException {
+        page = new TestPage();
+        Grid.open("about:blank");
+        String script = getScript();
+        Grid.driver().executeScript(script);
+        Thread.sleep(4000);
+
+        WebDriverWaitUtils.waitUntilWebPageIsValidated(page);
+        //Note: if the previous line passes and this fails something is really broken
+        SeLionAsserts.assertTrue(page.isPageValidated(), "TestPage did not pass pageValidations");
     }
 
     @Test(groups = { "functional" })
@@ -108,21 +123,19 @@ public class BasicPageImplTest {
         TestPage pageNotOpened = new TestPage("US", "TestWrongValidatorPage");
         TestPage pageTitleValidation = new TestPage("US", "PageTitleValidationPage");
 
-        SeLionAsserts.assertEquals(page.isCurrentPageInBrowser(), true, "Page is opened in the browser");
-        SeLionAsserts.assertEquals(pageNotOpened.isCurrentPageInBrowser(), false, "Page is not opened in the browser");
+        SeLionAsserts.assertEquals(page.isPageValidated(), true, "Page is opened in the browser");
+        SeLionAsserts.assertEquals(pageNotOpened.isPageValidated(), false, "Page is not opened in the browser");
         // Validate the page by pageTitle, which is the fallback if there are no pageValidators provided.
-        SeLionAsserts.assertEquals(pageTitleValidation.isCurrentPageInBrowser(), true, "Page is opened in the browser");
+        SeLionAsserts.assertEquals(pageTitleValidation.isPageValidated(), true, "Page is opened in the browser");
 
         pageTitleValidation.setPageTitle("Incorrect page title");
-        SeLionAsserts.assertEquals(pageTitleValidation.isCurrentPageInBrowser(), false,
-                "Page is not opened in the browser");
+        SeLionAsserts.assertEquals(pageTitleValidation.isPageValidated(), false, "Page is not opened in the browser");
 
         pageTitleValidation.setPageTitle("* JavaScript");
-        SeLionAsserts.assertEquals(pageTitleValidation.isCurrentPageInBrowser(), true, "Page is opened in the browser");
+        SeLionAsserts.assertEquals(pageTitleValidation.isPageValidated(), true, "Page is opened in the browser");
 
         pageTitleValidation.setPageTitle("* title");
-        SeLionAsserts.assertEquals(pageTitleValidation.isCurrentPageInBrowser(), false,
-                "Page is not opened in the browser");
+        SeLionAsserts.assertEquals(pageTitleValidation.isPageValidated(), false, "Page is not opened in the browser");
     }
 
     @Test(groups = { "functional" })

--- a/server/src/test/java/com/paypal/selion/grid/servlets/transfer/UploadRequestProcessorTest.java
+++ b/server/src/test/java/com/paypal/selion/grid/servlets/transfer/UploadRequestProcessorTest.java
@@ -16,7 +16,6 @@
 package com.paypal.selion.grid.servlets.transfer;
 
 import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 import javax.servlet.http.HttpServletRequest;
@@ -31,7 +30,6 @@ import org.testng.annotations.Test;
 import com.paypal.selion.grid.servlets.TransferServlet;
 import com.paypal.selion.grid.servlets.transfer.UploadRequestProcessor.ApplicationUploadRequestProcessor;
 import com.paypal.selion.grid.servlets.transfer.UploadRequestProcessor.MultipartUploadRequestProcessor;
-import com.paypal.selion.utils.ConfigParser;
 
 @PrepareForTest({ HttpServletRequest.class, HttpServletResponse.class, TransferServlet.class })
 public class UploadRequestProcessorTest extends PowerMockTestCase {


### PR DESCRIPTION
Also in this change set;
- Rename WebPage#isCurrentPageInBrowser to WebPage#isPageValiated
  to be more platform neutral
- New method WebDriverWaitUtils#waitUntilWebPageIsValidated()
- Add two new tests to test WebDriverWaitUtils#waitUntilWebPageIsValidated()
- Update several javadocs
- Unrelated change to fix locales used in archetype PageYAML examples
