### PR TITLE
Improved stacktraces for click and clickAndExpectOneOf

### DIFF
--- a/client/src/main/java/com/paypal/selion/platform/html/AbstractElement.java
+++ b/client/src/main/java/com/paypal/selion/platform/html/AbstractElement.java
@@ -25,6 +25,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.openqa.selenium.InvalidElementStateException;
 import org.openqa.selenium.NoAlertPresentException;
 import org.openqa.selenium.NoSuchElementException;
@@ -504,7 +506,7 @@ public abstract class AbstractElement implements Clickable, Hoverable {
                     continue;
                 }
                 if (expect instanceof WebPage) {
-                    WebDriverWaitUtils.waitUntilWebPageIsValidated((WebPage) expect);
+                    WebDriverWaitUtils.waitUntilPageIsValidated((WebPage) expect);
                     continue;
                 }
             }
@@ -585,11 +587,17 @@ public abstract class AbstractElement implements Clickable, Hoverable {
 
         try {
             WebDriverWait wait = new WebDriverWait(Grid.driver(), timeout);
+            wait.ignoring(NoSuchElementException.class);
+            wait.ignoring(ExpectOneOfException.class);
+            
             ExpectedCondition<?> matchedCondition = wait.until(new Function<WebDriver, ExpectedCondition<?>>() {
 
                 // find the first condition that matches and return it
                 @Override
                 public ExpectedCondition<?> apply(WebDriver webDriver) {
+                    StringBuilder sb = new StringBuilder();
+
+                    int i = 1;
                     for (final ExpectedCondition<?> condition : conditions) {
                         try {
                             Object value = condition.apply(webDriver);
@@ -599,11 +607,17 @@ public abstract class AbstractElement implements Clickable, Hoverable {
                                 }
                             } else if (value != null) {
                                 return condition;
-                            }
-                        } catch (NoSuchElementException e) { // NOSONAR
+                            }  
+                        } catch(WebDriverException e) {
+                            sb.append("\n\tObject " + i + ":\n");
+                            sb.append("\t" + ExceptionUtils.getRootCauseMessage(e).split("\n")[0] + "\n");
+                            sb.append("\t\t" + StringUtils.substringBetween(ExceptionUtils.getStackTrace(e), "\n"));
                         }
+                        
+                        i++;
                     }
-                    return null;
+                    
+                    throw new ExpectOneOfException(sb.toString());
                 }
             });
 
@@ -643,12 +657,19 @@ public abstract class AbstractElement implements Clickable, Hoverable {
         long timeout = Grid.getExecutionTimeoutValue() / 1000;
 
         try {
+
             WebDriverWait wait = new WebDriverWait(Grid.driver(), timeout);
-            Object expectedObj = wait.until(new Function<WebDriver, Object>() {
+            wait.ignoring(NoSuchElementException.class);
+            wait.ignoring(PageValidationException.class);
+
+            Object expectedObj = wait.ignoring(ExpectOneOfException.class).until(new Function<WebDriver, Object>() {
 
                 // find the first object that is matched and return it
                 @Override
                 public Object apply(WebDriver webDriver) {
+                    StringBuilder sb = new StringBuilder();
+
+                    int i = 1;
                     for (Object expect : expected) {
                         try {
                             if (expect instanceof AbstractElement) {
@@ -664,14 +685,19 @@ public abstract class AbstractElement implements Clickable, Hoverable {
                             } else if (expect instanceof WebPage) {
                                 WebPage w = (WebPage) expect;
 
-                                if (w.isPageValidated()) {
-                                    return expect;
-                                }
+                                w.validatePage();
+                                return expect;
                             }
-                        } catch (NoSuchElementException e) { // NOSONAR
+                        } catch (NoSuchElementException | PageValidationException e) { // NOSONAR
+                            sb.append("\n\tObject " + i + ": " + expect.getClass().getSimpleName() + "\n");
+                            sb.append("\t" + ExceptionUtils.getRootCauseMessage(e) + "\n");
+                            sb.append("\t\t" + StringUtils.substringBetween(ExceptionUtils.getStackTrace(e), "\n"));
                         }
+
+                        i++;
                     }
-                    return null;
+
+                    throw new ExpectOneOfException(sb.toString());
                 }
             });
 

--- a/client/src/main/java/com/paypal/selion/platform/html/ExpectOneOfException.java
+++ b/client/src/main/java/com/paypal/selion/platform/html/ExpectOneOfException.java
@@ -1,5 +1,5 @@
 /*-------------------------------------------------------------------------------------------------------------------*\
-|  Copyright (C) 2014 PayPal                                                                                          |
+|  Copyright (C) 2015 PayPal                                                                                          |
 |                                                                                                                     |
 |  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
 |  with the License.                                                                                                  |
@@ -16,14 +16,14 @@
 package com.paypal.selion.platform.html;
 
 /**
- * This exception is intended to encompass all exceptions that might be thrown when we validate pages
+ * This exception is used encompass all exceptions that occurred when multiple expected conditions are used in an OR
+ * fashion as a prequisite to further action.
  */
-public class PageValidationException extends RuntimeException {
+public class ExpectOneOfException extends RuntimeException {
 
-    private static final long serialVersionUID = 2293610118186851226L;
+    private static final long serialVersionUID = 4504271723751959171L;
 
-    public PageValidationException(String msg) {
+    public ExpectOneOfException(String msg) {
         super(msg);
     }
-
 }

--- a/client/src/main/java/com/paypal/selion/platform/html/WebPage.java
+++ b/client/src/main/java/com/paypal/selion/platform/html/WebPage.java
@@ -30,7 +30,9 @@ public interface WebPage {
      * Initialize the page by it's name and page path
      * 
      * @param pagePath
+     *            the path
      * @param pageClassName
+     *            the class name
      */
     void initPage(String pagePath, String pageClassName);
 
@@ -38,30 +40,31 @@ public interface WebPage {
      * Initialize the page by it's name, page path, and site locale
      * 
      * @param pagePath
+     *            the path
      * @param pageClassName
+     *            the class name
      * @param siteLocale
+     *            the locale to use
      */
     void initPage(String pagePath, String pageClassName, String siteLocale);
 
     /**
-     * Return initialization state
+     * @return initialization state
      */
     boolean isInitialized();
 
     /**
-     * Return the expected page title for this page
+     * @return the expected page title for this page
      */
     String getExpectedPageTitle();
 
     /**
-     * Return the current siteLocale setting for this page
+     * @return the current siteLocale setting for this page
      */
     String getSiteLocale();
 
     /**
-     * Return the WebPage object
-     * 
-     * @return a {@link WebPage}
+     * @return a {@link WebPage} object
      */
     WebPage getPage();
 
@@ -74,8 +77,8 @@ public interface WebPage {
     void validatePage();
 
     /**
-     * Return a boolean result based on the outcome of calling {@link WebPage#validatePage()} to validate the loaded
-     * page on the WebDriver session.
+     * Returns the outcome of calling {@link WebPage#validatePage()} to validate the loaded page on the WebDriver
+     * session.
      * 
      * @return <code>true</code> or <code>false</code>, if the page is validated, meaning all
      *         <code>pageValidators</code> pass

--- a/client/src/main/java/com/paypal/selion/platform/mobile/android/UiObject.java
+++ b/client/src/main/java/com/paypal/selion/platform/mobile/android/UiObject.java
@@ -301,7 +301,7 @@ public class UiObject implements UserinterfaceObject {
                 continue;
             }
             if (expect instanceof WebPage) {
-                WebDriverWaitUtils.waitUntilWebPageIsValidated((WebPage) expect);
+                WebDriverWaitUtils.waitUntilPageIsValidated((WebPage) expect);
                 continue;
             }
         }

--- a/client/src/main/java/com/paypal/selion/platform/mobile/ios/UIAElement.java
+++ b/client/src/main/java/com/paypal/selion/platform/mobile/ios/UIAElement.java
@@ -171,7 +171,7 @@ public class UIAElement implements UIAutomationElement {
                 continue;
             }
             if (expect instanceof WebPage) {
-                WebDriverWaitUtils.waitUntilWebPageIsValidated((WebPage) expect);
+                WebDriverWaitUtils.waitUntilPageIsValidated((WebPage) expect);
                 continue;
             }
         }

--- a/client/src/main/java/com/paypal/selion/platform/utilities/WebDriverWaitUtils.java
+++ b/client/src/main/java/com/paypal/selion/platform/utilities/WebDriverWaitUtils.java
@@ -28,6 +28,7 @@ import org.openqa.selenium.support.ui.WebDriverWait;
 import com.google.common.base.Preconditions;
 import com.paypal.selion.logger.SeLionLogger;
 import com.paypal.selion.platform.grid.Grid;
+import com.paypal.selion.platform.html.PageValidationException;
 import com.paypal.selion.platform.html.WebPage;
 import com.paypal.selion.platform.html.support.HtmlElementUtils;
 import com.paypal.test.utilities.logging.SimpleLogger;
@@ -55,6 +56,15 @@ public final class WebDriverWaitUtils {
 
     private static void waitForCondition(ExpectedCondition<?> condition, long timeoutInSeconds) {
         new WebDriverWait(Grid.driver(), timeoutInSeconds).until(condition);
+    }
+
+    private static void waitForConditionIgnoring(ExpectedCondition<?> condition, Class<? extends Throwable> ignoring) {
+        waitForConditionIgnoring(condition, ignoring, timeoutInSeconds());
+    }
+
+    private static void waitForConditionIgnoring(ExpectedCondition<?> condition, Class<? extends Throwable> ignoring,
+            long timeoutInSeconds) {
+        new WebDriverWait(Grid.driver(), timeoutInSeconds).ignoring(ignoring).until(condition);
     }
 
     /**
@@ -173,17 +183,18 @@ public final class WebDriverWaitUtils {
      * @param pageObject
      *            a {@link WebPage} instance.
      */
-    public static void waitUntilWebPageIsValidated(WebPage pageObject) {
+    public static void waitUntilPageIsValidated(WebPage pageObject) {
         logger.entering(pageObject);
         Preconditions.checkArgument(pageObject != null, "Please provide a valid instance of WebPage.");
         final WebPage w = (WebPage) pageObject;
         ExpectedCondition<Boolean> conditionToCheck = new ExpectedCondition<Boolean>() {
             @Override
             public Boolean apply(WebDriver webDriver) {
-                return w.isPageValidated();
+                w.validatePage();
+                return true;
             }
         };
-        waitForCondition(conditionToCheck);
+        waitForConditionIgnoring(conditionToCheck, PageValidationException.class);
         logger.exiting();
     }
 

--- a/client/src/main/java/com/paypal/selion/testcomponents/AbstractPage.java
+++ b/client/src/main/java/com/paypal/selion/testcomponents/AbstractPage.java
@@ -167,11 +167,6 @@ public abstract class AbstractPage implements WebPage {
         pageInitialized = true;
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see com.paypal.selion.platform.html.WebPage#initPage(java.lang.String, java.lang.String, java.lang.String)
-     */
     public void initPage(String pageDomain, String pageClassName, String siteLocale) {
         initPage(pageDomain, pageClassName);
         site = siteLocale;
@@ -181,22 +176,18 @@ public abstract class AbstractPage implements WebPage {
         return pageInitialized;
     }
 
-    @Override
     public String getExpectedPageTitle() {
         throw new UnsupportedOperationException("This operation is NOT supported.");
     }
 
-    @Override
     public String getSiteLocale() {
         return site;
     }
 
-    @Override
     public void validatePage() {
         throw new UnsupportedOperationException("This operation is NOT supported.");
     }
 
-    @Override
     public boolean isPageValidated() {
         throw new UnsupportedOperationException("This operation is NOT supported.");
     }

--- a/client/src/main/java/com/paypal/selion/testcomponents/BasicPageImpl.java
+++ b/client/src/main/java/com/paypal/selion/testcomponents/BasicPageImpl.java
@@ -46,20 +46,14 @@ public abstract class BasicPageImpl extends AbstractPage implements ParentTraits
         super();
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * Return the actual page title for this page
+    /**
+     * @return the actual title for this page
      */
     public String getActualPageTitle() {
         return Grid.driver().getTitle();
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see com.paypal.selion.platform.html.WebPage#getExpectedPageTitle()
-     */
+    @Override
     public String getExpectedPageTitle() {
         this.getObjectMap();
         return getPage().getPageTitle();
@@ -87,39 +81,23 @@ public abstract class BasicPageImpl extends AbstractPage implements ParentTraits
     }
 
     /**
-     * Require extended class to provide this implementation.
-     * 
-     * @return the page
+     * @return the page object
      */
     public abstract BasicPageImpl getPage();
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see com.paypal.selion.platform.html.ParentType#locateChildElements(java.lang.String)
-     */
     public List<WebElement> locateChildElements(String locator) {
         return HtmlElementUtils.locateElements(locator);
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see com.paypal.selion.platform.html.ParentType#locateChildElement(java.lang.String)
-     */
     public RemoteWebElement locateChildElement(String locator) {
         return HtmlElementUtils.locateElement(locator);
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see com.paypal.selion.platform.html.ParentType#getCurrentPage()
-     */
     public BasicPageImpl getCurrentPage() {
         return this;
     }
 
+    @Override
     public void validatePage() {
         getObjectMap();
 
@@ -173,7 +151,9 @@ public abstract class BasicPageImpl extends AbstractPage implements ParentTraits
      * Verify if the element is available based on a certain action
      * 
      * @param elementName
+     *            element to perform verification action on
      * @param action
+     *            verification action to perform
      */
     private void verifyElementByAction(String elementName, String action) {
         AbstractElement element = getAbstractElementThroughReflection(elementName);
@@ -184,35 +164,31 @@ public abstract class BasicPageImpl extends AbstractPage implements ParentTraits
         case "isPresent":
             if (!present) {
                 throw new PageValidationException(getClass().getSimpleName() + " isn't loaded in the browser, "
-                        + elementName + " isn't present.");
+                        + elementName + " with locator " + element.getLocator() + " isn't present.");
             }
             break;
         case "isVisible":
             if (!present || (present && !element.isVisible())) {
                 throw new PageValidationException(getClass().getSimpleName() + " isn't loaded in the browser, "
-                        + elementName + " isn't visible.");
+                        + elementName + " with locator " + element.getLocator() + " isn't visible.");
             }
             break;
         case "isEnabled":
             if (!present || (present && !element.isEnabled())) {
                 throw new PageValidationException(getClass().getSimpleName() + " isn't loaded in the browser, "
-                        + elementName + " isn't enabled.");
+                        + elementName + " with locator " + element.getLocator() + " isn't enabled.");
             }
             break;
         default:
             if (!present) {
                 throw new PageValidationException(getClass().getSimpleName() + " isn't loaded in the browser, "
-                        + elementName + " isn't present.");
+                        + elementName + " with locator " + element.getLocator() + " isn't present.");
             }
             break;
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see com.paypal.selion.platform.html.WebPage#isPageValidated()
-     */
+    @Override
     public boolean isPageValidated() {
         try {
             validatePage();

--- a/client/src/test/java/com/paypal/selion/platform/grid/SeLionSeleniumTest.java
+++ b/client/src/test/java/com/paypal/selion/platform/grid/SeLionSeleniumTest.java
@@ -86,7 +86,7 @@ public class SeLionSeleniumTest {
         try {
             Config.setConfigProperty(Config.ConfigProperty.EXECUTION_TIMEOUT, "20000");
             Grid.driver().get(url);
-            WebDriverWaitUtils.waitUntilWebPageIsValidated(new BasicPageImpl() {
+            WebDriverWaitUtils.waitUntilPageIsValidated(new BasicPageImpl() {
                 @Override
                 public BasicPageImpl getPage() {
                     return this;

--- a/client/src/test/java/com/paypal/selion/platform/html/AbstractElementTest.java
+++ b/client/src/test/java/com/paypal/selion/platform/html/AbstractElementTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.SessionNotFoundException;
 import org.openqa.selenium.support.ui.ExpectedCondition;
@@ -116,7 +117,7 @@ public class AbstractElementTest {
         assertTrue(expected.equals(success)); // success page should be found
     }
 
-    @Test(groups = { "functional" }, expectedExceptions = { org.openqa.selenium.TimeoutException.class })
+    @Test(groups = { "functional" }, expectedExceptions = { TimeoutException.class })
     @WebTest
     public void testClickAndExpectOneOfExpectedConditionsNegativeTest() throws IOException {
         Grid.driver().get(TestServerUtils.getTestEditableURL());
@@ -136,7 +137,6 @@ public class AbstractElementTest {
         }
     }
 
-    // failing, correct that
     @Test(groups = { "functional" })
     @WebTest
     public void testClickAndExpectOneOf() throws IOException, InterruptedException {
@@ -163,7 +163,7 @@ public class AbstractElementTest {
         assertTrue(expected3.equals(inMemoryPage));
     }
 
-    @Test(groups = { "functional" }, expectedExceptions = { org.openqa.selenium.TimeoutException.class })
+    @Test(groups = { "functional" }, expectedExceptions = { TimeoutException.class })
     @WebTest
     public void testClickAndExpectOneOfNegativeTest() throws IOException {
         Grid.driver().get(TestServerUtils.getTestEditableURL());

--- a/client/src/test/java/com/paypal/selion/testcomponents/BasicPageImplTest.java
+++ b/client/src/test/java/com/paypal/selion/testcomponents/BasicPageImplTest.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.IOException;
 
 import org.apache.commons.io.FileUtils;
+import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -57,16 +58,26 @@ public class BasicPageImplTest {
 
     @Test(groups = { "functional" })
     @WebTest
-    public void testWebPageIsValidated() throws InterruptedException, IOException {
+    public void testWaitUntilPageIsValidated() throws InterruptedException, IOException {
         page = new TestPage();
         Grid.open("about:blank");
         String script = getScript();
         Grid.driver().executeScript(script);
         Thread.sleep(4000);
 
-        WebDriverWaitUtils.waitUntilWebPageIsValidated(page);
-        //Note: if the previous line passes and this fails something is really broken
-        SeLionAsserts.assertTrue(page.isPageValidated(), "TestPage did not pass pageValidations");
+        WebDriverWaitUtils.waitUntilPageIsValidated(page);
+    }
+
+    @Test(groups = { "functional" }, expectedExceptions = { TimeoutException.class })
+    @WebTest
+    public void testWaitUntilPageIsValidated_Neg() throws InterruptedException, IOException {
+        page = new TestPage("US", "TestWrongValidatorPage");
+        Grid.open("about:blank");
+        String script = getScript();
+        Grid.driver().executeScript(script);
+        Thread.sleep(4000);
+
+        WebDriverWaitUtils.waitUntilPageIsValidated(page);
     }
 
     @Test(groups = { "functional" })


### PR DESCRIPTION
New stacktrace for click(Object):

```
Caused by: com.paypal.selion.platform.html.PageValidationException: TestPage isn't loaded in the browser, fieldXTextField with locator //input[@id='fieldXId'] isn't enabled.
    at com.paypal.selion.testcomponents.BasicPageImpl.verifyElementByAction(BasicPageImpl.java:202)
    at com.paypal.selion.testcomponents.BasicPageImpl.validatePage(BasicPageImpl.java:146)
    at com.paypal.selion.platform.html.AbstractElement$2.apply(AbstractElement.java:508)
    at com.paypal.selion.platform.html.AbstractElement$2.apply(AbstractElement.java:1)
    at org.openqa.selenium.support.ui.FluentWait.until(FluentWait.java:209)
    ... 26 more
```

New stacktrace for clickAndExpectOneOf(Object):

```
Caused by: com.paypal.selion.platform.html.ExpectOneOfException: 
    Object 1: TestPage
    PageValidationException: TestPage isn't loaded in the browser, fieldXTextField with locator //input[@id='fieldXId'] isn't enabled.
            at com.paypal.selion.testcomponents.BasicPageImpl.verifyElementByAction(BasicPageImpl.java:202)
    Object 2: TestPage
    PageValidationException: TestPage isn't loaded in the browser, fieldXTextField with locator //input[@id='fieldXId'] isn't enabled.
            at com.paypal.selion.testcomponents.BasicPageImpl.verifyElementByAction(BasicPageImpl.java:202)
    at com.paypal.selion.platform.html.AbstractElement$4.apply(AbstractElement.java:694)
    at com.paypal.selion.platform.html.AbstractElement$4.apply(AbstractElement.java:1)
    at org.openqa.selenium.support.ui.FluentWait.until(FluentWait.java:209)
    ... 26 more
```

New stacktrace for clickAndExpectOneOf(List ExpectedCondition):

```
Caused by: com.paypal.selion.platform.html.ExpectOneOfException: 
    Object 1: 
    InvalidSelectorException: The given selector css=input[name='btnWrong'] is either invalid or does not result in a WebElement. The following error occurred:
        InvalidSelectorError: An invalid or illegal selector was specified
    Object 2: 
    InvalidSelectorException: The given selector css=input[name='btnWrong'] is either invalid or does not result in a WebElement. The following error occurred:
        InvalidSelectorError: An invalid or illegal selector was specified
    at com.paypal.selion.platform.html.AbstractElement$2.apply(AbstractElement.java:620)
    at com.paypal.selion.platform.html.AbstractElement$2.apply(AbstractElement.java:1)
    at org.openqa.selenium.support.ui.FluentWait.until(FluentWait.java:209)
    ... 26 more
```
