### PR TITLE
Enhance hub servlet ListAllNodes

### DIFF
--- a/server/src/main/java/com/paypal/selion/grid/servlets/GridForceRestartDelegateServlet.java
+++ b/server/src/main/java/com/paypal/selion/grid/servlets/GridForceRestartDelegateServlet.java
@@ -93,10 +93,7 @@ public class GridForceRestartDelegateServlet extends RegistryBasedServlet {
                     continue;
                 }
 
-                // TODO :: Address the assumption here that any node which uses SeLionRemoteProxy also has
-                // NodeForceRestartServlet available. Without truth in this assumption, the call to
-                // proxy.forceNodeShutdown() and proxy.requestNodeShutdown will do nothing.
-                if (proxy instanceof SeLionRemoteProxy) {
+                if ((proxy instanceof SeLionRemoteProxy) && (((SeLionRemoteProxy) proxy).supportsForceShutdown())) {
                     if (isForcedRestart) {
                         LOGGER.info("Sending forced restart request to " + proxy.getId());
                         ((SeLionRemoteProxy) proxy).forceNodeShutdown();
@@ -121,7 +118,6 @@ public class GridForceRestartDelegateServlet extends RegistryBasedServlet {
             writer.write("<ul>");
             writer.write("<li id='li_1' >");
             writer.write("<label class='description' for='element_1'>List of nodes to restart </label>");
-            writer.write("<span>");
 
             ProxySet proxies = this.getRegistry().getAllProxies();
             Iterator<RemoteProxy> iterator = proxies.iterator();
@@ -132,21 +128,20 @@ public class GridForceRestartDelegateServlet extends RegistryBasedServlet {
                     continue;
                 }
 
-                // TODO :: Address the assumption here that any node which uses SeLionRemoteProxy also has
-                // NodeForceRestartServlet available. Without truth in this assumption, the call to
-                // proxy.forceNodeShutdown() will do nothing.
-                if (proxy instanceof SeLionRemoteProxy) {
+                if ((proxy instanceof SeLionRemoteProxy) && (((SeLionRemoteProxy) proxy).supportsForceShutdown())) {
                     writer.write("<input name='nodes' class='element checkbox' type='checkbox' value='" + proxy.getId()
                             + "' />");
-                    writer.write("<label class='choice'>" + proxy.getId() + "</label>");
+                    writer.write(((SeLionRemoteProxy) proxy).isScheduledForRecycle() ? "<label class='choice'>"
+                            + proxy.getId() + " (restart scheduled)</label>" : "<label class='choice'>" + proxy.getId()
+                            + "</label>");
                     nodesPresent = true;
                 } else {
                     LOGGER.warning("Node " + proxy.getId() + " does not support force restart.");
                 }
             }
 
-            writer.write("</span></li>");
-            String defaultMsg = "<label class='choice'>No nodes are available to restart</label>";
+            writer.write("</li>");
+            String defaultMsg = "<div style=\"padding-top: 20px\"><label class='choice'>No nodes are available to restart</label class='choice'></div>";
             if (nodesPresent) {
                 defaultMsg = "<li class='buttons'><input type='hidden' name='form_id' value='restart_nodes' />"
                         + "<input id='saveForm' class='button_text' type='submit' name='submit' value='Restart'/>"

--- a/server/src/main/java/com/paypal/selion/grid/servlets/PasswordChangeServlet.java
+++ b/server/src/main/java/com/paypal/selion/grid/servlets/PasswordChangeServlet.java
@@ -26,7 +26,6 @@ import javax.servlet.http.HttpSession;
 
 import org.apache.commons.io.IOUtils;
 
-import com.paypal.selion.pojos.SeLionGridConstants;
 import com.paypal.selion.utils.AuthenticationHelper;
 import com.paypal.selion.utils.ServletHelper;
 
@@ -34,6 +33,11 @@ import com.paypal.selion.utils.ServletHelper;
  * This servlet provides the ability to change the password for servlets which require/use {@link LoginServlet}
  */
 public class PasswordChangeServlet extends HttpServlet {
+
+    /**
+     * Resource path to the password change html template file
+     */
+    public static final String RESOURCE_PAGE_FILE = "/pages/changePageGetDetails.html";
 
     private static final long serialVersionUID = 1L;
 
@@ -46,8 +50,7 @@ public class PasswordChangeServlet extends HttpServlet {
     private void askForCredentialsPage(PrintWriter writer) throws IOException {
         String changePasswordMessage = "Fill out the form to change the management console password";
 
-        String template = IOUtils.toString(this.getClass().getResourceAsStream(
-                SeLionGridConstants.PASSWORD_CHANGE_PAGE_RESOURCE), "UTF-8");
+        String template = IOUtils.toString(this.getClass().getResourceAsStream(RESOURCE_PAGE_FILE), "UTF-8");
         writer.write(String.format(template, PasswordChangeServlet.class.getSimpleName(), changePasswordMessage));
     }
 

--- a/server/src/main/java/com/paypal/selion/grid/servlets/ProxyInfo.java
+++ b/server/src/main/java/com/paypal/selion/grid/servlets/ProxyInfo.java
@@ -1,0 +1,255 @@
+/*-------------------------------------------------------------------------------------------------------------------*\
+|  Copyright (C) 2015 PayPal                                                                                          |
+|                                                                                                                     |
+|  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
+|  with the License.                                                                                                  |
+|                                                                                                                     |
+|  You may obtain a copy of the License at                                                                            |
+|                                                                                                                     |
+|       http://www.apache.org/licenses/LICENSE-2.0                                                                    |
+|                                                                                                                     |
+|  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed   |
+|  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for  |
+|  the specific language governing permissions and limitations under the License.                                     |
+\*-------------------------------------------------------------------------------------------------------------------*/
+
+package com.paypal.selion.grid.servlets;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.gson.JsonObject;
+
+import net.jcip.annotations.Immutable;
+import org.openqa.grid.common.RegistrationRequest;
+import org.openqa.grid.internal.RemoteProxy;
+import org.openqa.grid.internal.TestSlot;
+import org.openqa.selenium.remote.CapabilityType;
+
+import com.paypal.selion.node.servlets.LogServlet;
+import com.paypal.selion.proxy.SeLionRemoteProxy;
+
+/**
+ * Internal only. Used to create an immutable response object for the {@link ListAllNodes} servlet which gets serialized
+ * application/json.
+ */
+@Immutable
+@SuppressWarnings("unused")
+final class ProxyInfo {
+    /**
+     * Information not available
+     */
+    private static final String NOT_AVAILABLE = "not available";
+
+    /**
+     * Proxy is online
+     */
+    private static final String ONLINE = "online";
+
+    /**
+     * Proxy is offline
+     */
+    private static final String OFFLINE = "offline";
+
+    /**
+     * The url to view logs (via LogServlet) on the proxy. Defaults to {@value #NOT_AVAILABLE}
+     * 
+     * @see SeLionRemoteProxy#supportsViewLogs()
+     */
+    private String logsLocation = NOT_AVAILABLE;
+
+    /**
+     * @see RemoteProxy#isBusy()
+     */
+    private boolean isBusy;
+
+    /**
+     * @see RemoteProxy#getResourceUsageInPercent()
+     */
+    private float percentResourceUsage;
+
+    /**
+     * @see RemoteProxy#getTotalUsed()
+     */
+    private int totalUsed;
+
+    /**
+     * @see SeLionRemoteProxy#isScheduledForRecycle(). Defaults to false
+     */
+    private boolean isShuttingDown;
+
+    /**
+     * @see SeLionRemoteProxy#getTotalSessionsComplete(). Defaults to -1
+     */
+    private int totalSessionsComplete = -1;
+
+    /**
+     * @see SeLionRemoteProxy#getTotalSessionsStarted(). Defaults to -1
+     */
+    private int totalSessionsStarted = -1;
+
+    /**
+     * @see SeLionRemoteProxy#getUptimeInMinutes(). Defaults to -1
+     */
+    private long uptimeInMinutes = -1;
+
+    /**
+     * @see RemoteProxy#getConfig()
+     */
+    private Map<String, Object> configuration;
+
+    /**
+     * Calls {@link RemoteProxy#getStatus()} to determine if proxy is {@value #ONLINE} or {@value #OFFLINE}. Defaults to
+     * {@value #NOT_AVAILABLE}
+     */
+    private String status = NOT_AVAILABLE;
+
+    /**
+     * Calls {@link RemoteProxy#getStatus()} to determine proxy version. Defaults to {@value #NOT_AVAILABLE}
+     */
+    private String version = NOT_AVAILABLE;
+
+    /**
+     * Calls {@link RemoteProxy#getStatus()} to determine proxy OS. Defaults to {@value #NOT_AVAILABLE}
+     */
+    private String os = NOT_AVAILABLE;
+
+    /**
+     * proxy usage by slot type
+     */
+    private Map<String, SlotInfo> slotUsage;
+
+    private final class SlotInfo {
+        private int used;
+        private int percentUsed;
+        private final int maxInstances;
+
+        private SlotInfo() {
+            this(1);
+        }
+
+        private SlotInfo(int maxInstances) {
+            used = 0;
+            percentUsed = 0;
+            this.maxInstances = maxInstances;
+        }
+
+        private void addUsed() {
+            used++;
+            updateUsage();
+        }
+
+        private void updateUsage() {
+            percentUsed = 100 * used / maxInstances;
+        }
+    }
+
+    private ProxyInfo() {
+        // defeat instantiation.
+    }
+
+    /**
+     * Initializes proxy information from the supplied {@link RemoteProxy} object. Queries the proxy for status over
+     * HTTP.
+     *
+     * @param proxy
+     *            the {@link RemoteProxy}
+     */
+    ProxyInfo(RemoteProxy proxy) {
+        this(proxy, true);
+    }
+
+    /**
+     * Initializes proxy information from the supplied {@link RemoteProxy} object
+     * 
+     * @param proxy
+     *            the {@link RemoteProxy}
+     * @param queryStatus
+     *            whether to query the node status over HTTP via /wd/hub/status
+     */
+    ProxyInfo(RemoteProxy proxy, boolean queryStatus) {
+        // selenium supported features
+        isBusy = proxy.isBusy();
+        percentResourceUsage = proxy.getResourceUsageInPercent();
+        totalUsed = proxy.getTotalUsed();
+        configuration = proxy.getConfig();
+
+        determineStatus(proxy, queryStatus);
+        initUsageBySlot(proxy);
+
+        // SelionRemoteProxy only
+        initSeLionRemoteProxySpecificValues(proxy);
+
+    }
+
+    private void determineStatus(RemoteProxy proxy, boolean doQuery) {
+        if (!doQuery) {
+            return;
+        }
+
+        status = "offline";
+        try {
+            JsonObject value = proxy.getStatus().get("value").getAsJsonObject();
+            status = "online";
+            version = value.get("build").getAsJsonObject().get("version").getAsString();
+            StringBuilder buf = new StringBuilder();
+            buf.append(value.get("os").getAsJsonObject().get("name").getAsString());
+            buf.append(" ");
+            buf.append(value.get("os").getAsJsonObject().get("version").getAsString());
+            os = buf.toString();
+        } catch (Exception e) { // NOSONAR
+            // ignore
+        }
+    }
+
+    private void initUsageBySlot(RemoteProxy proxy) {
+        // figure out usage by slot type
+        slotUsage = new HashMap<>();
+        for (TestSlot slot : proxy.getTestSlots()) {
+            String slotType = getSlotType(slot);
+            SlotInfo info = slotUsage.get(slotType);
+            if (info == null) {
+                info = new SlotInfo(getMaxInstances(slot));
+            }
+            if (slot.getSession() != null) {
+                info.addUsed();
+            }
+            slotUsage.put(slotType, info);
+        }
+    }
+
+    // SeLion specific features
+    private void initSeLionRemoteProxySpecificValues(RemoteProxy proxy) {
+        if (SeLionRemoteProxy.class.getCanonicalName().equals(
+                proxy.getOriginalRegistrationRequest().getRemoteProxyClass())) {
+            SeLionRemoteProxy srp = (SeLionRemoteProxy) proxy;
+
+            // figure out if the proxy is scheduled to shutdown
+            isShuttingDown = srp.isScheduledForRecycle();
+
+            // update the logsLocation if the proxy supports LogServlet
+            if (srp.supportsViewLogs()) {
+                logsLocation = proxy.getRemoteHost().toExternalForm() + "/extra/" + LogServlet.class.getSimpleName();
+            }
+
+            totalSessionsStarted = srp.getTotalSessionsStarted();
+            totalSessionsComplete = srp.getTotalSessionsComplete();
+            uptimeInMinutes = srp.getUptimeInMinutes();
+        }
+    }
+
+    private String getSlotType(TestSlot slot) {
+        Map<String, Object> caps = slot.getCapabilities();
+        String browserName = (String) caps.get(CapabilityType.BROWSER_NAME);
+        String version = (String) caps.get(CapabilityType.VERSION);
+        if (version != null) {
+            return browserName.concat(":v").concat(version);
+        }
+        return browserName;
+    }
+
+    private int getMaxInstances(TestSlot slot) {
+        Map<String, Object> caps = slot.getCapabilities();
+        return Integer.parseInt(caps.get(RegistrationRequest.MAX_INSTANCES).toString());
+    }
+}

--- a/server/src/main/java/com/paypal/selion/grid/servlets/SauceConfigChangeServlet.java
+++ b/server/src/main/java/com/paypal/selion/grid/servlets/SauceConfigChangeServlet.java
@@ -42,16 +42,21 @@ import com.paypal.selion.utils.ServletHelper;
 
 /**
  * This {@link RegistryBasedServlet} based servlet update the Sauce Configuration json file based on the input provided
- * via POST operation and re-load the SauceConfigReader proerties. For GET request it will return the
+ * via POST operation and re-load the SauceConfigReader properties. For GET request it will return the
  * updateSauceConfigPage.html content. URL of the Servlet :
- * <code>http://{hub-host}:{hub-port}/grid/admin/SauceConfigChangeServlet</code>.
+ * <code>http://{hub-host}:{hub-port}/grid/admin/SauceConfigChangeServlet</code>. <br>
  * <br>
- * <br>
- * This requires the hub to also have {@link LoginServlet} available. 
+ * This requires the hub to also have {@link LoginServlet} available.
  */
 public class SauceConfigChangeServlet extends RegistryBasedServlet {
 
+    /**
+     * Resource path to the sauce config html file
+     */
+    public static final String RESOURCE_PAGE_FILE = "/pages/updateSauceConfigPage.html";
+
     private static final long serialVersionUID = 1L;
+
     private static final SeLionGridLogger LOGGER = SeLionGridLogger.getLogger(SauceConfigChangeServlet.class);
 
     public SauceConfigChangeServlet(Registry registry) {
@@ -73,8 +78,7 @@ public class SauceConfigChangeServlet extends RegistryBasedServlet {
     }
 
     private void loadSauceConfigPage(PrintWriter writer) throws IOException {
-        String finalHtml = IOUtils.toString(this.getClass().getResourceAsStream(
-                SeLionGridConstants.SAUCE_CONFIG_UPDATE_PAGE_RESOURCE), "UTF-8");
+        String finalHtml = IOUtils.toString(this.getClass().getResourceAsStream(RESOURCE_PAGE_FILE), "UTF-8");
         writer.write(finalHtml);
     }
 

--- a/server/src/main/java/com/paypal/selion/pojos/SeLionGridConstants.java
+++ b/server/src/main/java/com/paypal/selion/pojos/SeLionGridConstants.java
@@ -82,24 +82,9 @@ public class SeLionGridConstants {
     public static final String GRID_HOME_PAGE_URL = GRID_PAGES_URL_PATH_PREFIX + "gridHomePage.html";
 
     /**
-     * Resource path to the password change html template file
-     */
-    public static final String PASSWORD_CHANGE_PAGE_RESOURCE = "/pages/changePageGetDetails.html";
-
-    /**
-     * Resource path to the grid auto upgrade html template file
-     */
-    public static final String GRID_AUTO_UPGRADE_PAGE_RESOURCE = "/pages/gridAutoUpgradePage.html";
-
-    /**
      * URL to the SeLion sauce grid home page
      */
     public static final String SAUCE_GRID_HOMEPAGE_URL = GRID_PAGES_URL_PATH_PREFIX + "sauceGridHomePage.html";
-
-    /**
-     * Resource path to the sauce config html file
-     */
-    public static final String SAUCE_CONFIG_UPDATE_PAGE_RESOURCE = "/pages/updateSauceConfigPage.html";
 
     /**
      * Resource path to the default SeLionConfig.json file

--- a/server/src/main/java/com/paypal/selion/utils/AuthenticationHelper.java
+++ b/server/src/main/java/com/paypal/selion/utils/AuthenticationHelper.java
@@ -67,7 +67,7 @@ public final class AuthenticationHelper {
      * @return - <code>true</code> if the credentials were valid.
      */
     public static boolean authenticate(String userName, String userPassword) {
-        LOGGER.entering(userName, userPassword.replaceAll(".", "*"));
+        LOGGER.entering(userName, StringUtils.isBlank(userPassword) ? userPassword : userPassword.replaceAll(".", "*"));
         boolean validLogin = false;
         byte[] currentAuthData;
         byte[] hashedInputData;

--- a/server/src/main/resources/com/paypal/selion/css/listAllNodes.css
+++ b/server/src/main/resources/com/paypal/selion/css/listAllNodes.css
@@ -1,0 +1,80 @@
+/*-------------------------------------------------------------------------------------------------------------------*\
+|  Copyright (C) 2015 PayPal                                                                                          |
+|                                                                                                                     |
+|  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
+|  with the License.                                                                                                  |
+|                                                                                                                     |
+|  You may obtain a copy of the License at                                                                            |
+|                                                                                                                     |
+|       http://www.apache.org/licenses/LICENSE-2.0                                                                    |
+|                                                                                                                     |
+|  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed   |
+|  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for  |
+|  the specific language governing permissions and limitations under the License.                                     |
+\*-------------------------------------------------------------------------------------------------------------------*/
+
+.version-info {
+  float: right !important;
+}
+.busy {
+  opacity: 0.4 !important;
+  filter: alpha(opacity=40) !important;
+}
+.icon {
+  display: inline;
+  padding-left: 2px;
+  padding-right: 2px;
+  cursor: default;
+}
+.offline {
+  background-color: rgba(225, 0, 0, 0.25) !important;
+}
+.shuttingdown {
+  background-color: rgba(37, 206, 215, 0.25) !important;
+}
+#content li {
+  list-style-type: none;
+}
+#content div.left-cell {
+  box-sizing: border-box;
+  display: table-cell;
+  padding-left: 5px;
+  padding-right: 5px;
+  width: 300px;
+}
+#content div.right-cell {
+  box-sizing: border-box;
+  display: table-cell;
+  padding-left: 5px;
+  padding-right: 5px;
+  width: 300px;
+}
+#content div.row {
+  background-color: #f0f0f0;
+  display: block;
+  padding: 10px;
+}
+#content div.header {
+  background-color: rgba(0, 93, 97, 0.25);
+  display: block;
+  padding: 5px;
+}
+#content a:visited, #content a, #content a:hover, .icon a {
+  color: rgba(0, 93, 97, 0.75);
+}
+#content li.icon a {
+  background-color: #fefefe;
+  height: 16px;
+}
+#content li.icon img {
+  vertical-align: top;
+  height: 16px !important;
+}
+#content div.icon-row {
+  padding-left: 5px;
+  padding-right: 5px;
+}
+.javascript-enabled {
+  display: none !important;
+  visibility: hidden !important;
+}

--- a/server/src/main/resources/com/paypal/selion/html/listAllNodes.html
+++ b/server/src/main/resources/com/paypal/selion/html/listAllNodes.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html PUBLIC '-//W3C//DTD XHTML 1.0 Transitional//EN'
+    'http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd'>
+<!---------------------------------------------------------------------------------------------------------------------
+|  Copyright (C) 2015 PayPal                                                                                          |
+|                                                                                                                     |
+|  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
+|  with the License.                                                                                                  |
+|                                                                                                                     |
+|  You may obtain a copy of the License at                                                                            |
+|                                                                                                                     |
+|       http://www.apache.org/licenses/LICENSE-2.0                                                                    |
+|                                                                                                                     |
+|  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed   |
+|  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for  |
+|  the specific language governing permissions and limitations under the License.                                     |
+---------------------------------------------------------------------------------------------------------------------->
+<html xmlns='http://www.w3.org/1999/xhtml'>
+<head>
+  <meta http-equiv='Content-Type' content='text/html; charset=UTF-8'>
+  <title>Grid Management Console</title>
+  <link rel="stylesheet" type="text/css" href="/grid/resources/form/view.css" media="all">
+  <link rel="stylesheet" type="text/css" href="/grid/resources/com/paypal/selion/css/listAllNodes.css" media="all"/>
+  <script type="text/javascript" src="/grid/resources/form/view.js"></script>
+  <script type="text/javascript" src="/grid/resources/form/jquery.min.js"></script>
+  <script type="text/javascript">
+    var nodeJson = Object.freeze(%s);
+  </script>
+  <script type="text/javascript" src="/grid/resources/com/paypal/selion/js/listAllNodes.js"></script>
+</head>
+
+<body id="main_body">
+<img id="top" src="/grid/resources/form/top.png" alt="">
+
+<div id="form_container">
+  <div id="main" style="margin: 20px 20px 0; padding:0 0 20px;">
+    <div class='form_description'>
+      <h2>SeLion Grid - Node Console</h2>
+    </div>
+    <noscript><p class="error">JavaScript required</p></noscript>
+    <div id="content" class="javascript-enabled"></div>
+    <br>
+    <div id="footer">
+      <p>Created by the <a href="http://selion.io">SeLion</a> project</p>
+    </div>
+  </div>
+</div>
+<img id="bottom" src="/grid/resources/form/bottom.png" alt="">
+</body>
+</html>

--- a/server/src/main/resources/com/paypal/selion/js/listAllNodes.js
+++ b/server/src/main/resources/com/paypal/selion/js/listAllNodes.js
@@ -1,0 +1,209 @@
+/*-------------------------------------------------------------------------------------------------------------------*\
+|  Copyright (C) 2015 PayPal                                                                                          |
+|                                                                                                                     |
+|  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
+|  with the License.                                                                                                  |
+|                                                                                                                     |
+|  You may obtain a copy of the License at                                                                            |
+|                                                                                                                     |
+|       http://www.apache.org/licenses/LICENSE-2.0                                                                    |
+|                                                                                                                     |
+|  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed   |
+|  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for  |
+|  the specific language governing permissions and limitations under the License.                                     |
+\*-------------------------------------------------------------------------------------------------------------------*/
+
+(function main() {
+  "use strict";
+
+  // add the slot images or text if the png is not available.
+  $(document).on('updateIcons', function renderSlotIcons() {
+    $('.icon').each(function (index, element) {
+      var browserType = $(element).attr('data-value'),
+        proxyIndex = $(element).parent().attr('data-src'),
+        // strip the version and replace space with '_'
+        icon = browserType.replace(new RegExp(':v(.*)$', 'g'), '').replace(new RegExp(' ', 'g'), '_') + '.png',
+        // extract the version, if present
+        version = browserType.replace(new RegExp('^(.*):', 'g'), ''),
+        iconPath = '/grid/resources/org/openqa/grid/images/' + icon,
+        slotUsage = nodeJson[proxyIndex].slotUsage,
+        toolTip = JSON.stringify(slotUsage[browserType]).replace(new RegExp('"', 'g'), ''),
+        busyState = (function () {
+          if (slotUsage[browserType].used > 0) {
+            return ' class="busy"';
+          }
+          return '';
+        }());
+
+      version = (version !== browserType) ? version + ':' : '';
+
+      //attempt to load the icon via async http call. use image on success.
+      $.get(iconPath, function httpGet(data, status) {
+        if (status === "success") {
+          $(element).append(version + '<img src="' + iconPath + '" title="' + toolTip + '"' + busyState + '>');
+        }
+      }).fail(function () {
+        $(element).append(version + '<a title="' + toolTip + '"' + busyState + '>' + browserType + '</a>');
+      });
+    });
+  });
+
+  // render the node info
+  $(document).ready(function renderNodes() {
+    //show the javascript-enabled-div 'main'
+    $('.javascript-enabled').removeAttr('class');
+
+    // new parent div for all proxy info
+    var proxyDiv = $('<div>');
+
+    // # of nodes connected
+    $('<h4>').text(nodeJson.length + ' node(s) connected').appendTo('#content');
+
+    //iterate over each node and create node info container
+    $(nodeJson).each(function addNodeInfo(index, node) {
+      // new div for proxy info list items
+      var proxyInfoDiv = $('<div>').attr('class', 'row'),
+        // new left and right columns of proxy info list items
+        proxyInfoLeftColumnDiv = $('<div>').attr('class', 'left-cell'),
+        proxyInfoRightColumnDiv = $('<div>').attr('class', 'right-cell'),
+        // strips the package from the proxy class name and returns the result
+        proxyClass = (function () {
+          var p = node.configuration.proxy,
+            indexOf = p.lastIndexOf('.');
+          if (indexOf === -1) {
+            return p;
+          }
+          return p.substr(indexOf + 1, p.length);
+        }());
+
+      // add the proxy header row
+      function createProxyHeaderDiv() {
+        var div = $('<div>'),
+          // sets the header css class based on proxy status
+          headerCssClass = (function () {
+            var cssClass = 'header';
+            if (node.status === 'offline') {
+              cssClass += ' offline';
+            }
+            if (node.isShuttingDown) {
+              cssClass += ' shuttingdown';
+            }
+            return cssClass;
+          }());
+
+        // adds the node version and os, if available
+        function createVersionAndOSSpan() {
+          var span = $('<span>').attr('class', 'version-info');
+          if (node.status === 'online') {
+            $(span).text('v' + node.version);
+          }
+          if (node.os !== 'not available') {
+            $(span).text($(span).text() + ' on ' + node.os);
+          }
+          return span;
+        }
+
+        // add the remote host / slot id info
+        function createRemoteHostSpan() {
+          var span = $('<span>');
+          if (node.logsLocation !== 'not available') {
+            $('<a>')
+              .attr('target', '_blank')
+              .attr('href', node.logsLocation)
+              .text(node.configuration.remoteHost)
+              .appendTo(span);
+          } else {
+            $(span).text(node.configuration.remoteHost);
+          }
+          return span;
+        }
+
+        return $(div)
+          .attr('class', headerCssClass)
+          .append(createRemoteHostSpan())
+          .append(createVersionAndOSSpan());
+      }
+
+      // add the slot info
+      function addSlotInfo(slots) {
+        var slotsDiv = $('<div>')
+          .attr('class', 'icon-row')
+          .attr('data-src', index);
+        if (typeof slots !== 'object') {
+          return;
+        }
+        $.each(slots, function addli(k, v) {
+          $(slotsDiv).append($('<li>').attr('class', 'icon').attr('data-value', k));
+        });
+        return slotsDiv;
+      }
+
+      // add a <li> item to display
+      function createInfoLi(label, item, valueType, isSelionItem) {
+        // sanitize known values which mean the proxy did not provide any data.
+        function supported(something) {
+          if (proxyClass === 'SeLionRemoteProxy') {
+            return something;
+          }
+          try {
+            if ((something === undefined) || (something === null) || (something === -1)) {
+              return 'not supported';
+            }
+          } catch (err) {
+            return 'not supported';
+          }
+          return something;
+        }
+
+        if (isSelionItem === undefined) {
+          isSelionItem = false;
+        }
+        if (valueType === undefined) {
+          valueType = '';
+        }
+        if (isSelionItem && (supported(item) === 'not supported')) {
+          return '';
+        }
+        return $('<li><b>' + label + '</b>: ' + item + ' ' + valueType + ' </li>');
+      }
+
+      // add the header row
+      createProxyHeaderDiv().appendTo(proxyDiv);
+
+      // add left column list items
+      $(proxyInfoLeftColumnDiv)
+        .append(createInfoLi('Proxy', proxyClass))
+        .append(createInfoLi('Busy', node.isBusy))
+        .append(createInfoLi('Uptime', node.uptimeInMinutes, 'min', true))
+        .append(createInfoLi('Resource usage', node.percentResourceUsage, '&#37;', false))
+        .append(createInfoLi('Idle timeout', node.configuration.timeout, 'ms', false))
+        .append(createInfoLi('Recycyle wait timeout', node.configuration.nodeRecycleThreadWaitTimeout, 'sec', true))
+        .append(createInfoLi('Max new sessions allowed', node.configuration.uniqueSessionCount, '', true));
+      $(proxyInfoLeftColumnDiv).appendTo(proxyInfoDiv);
+
+      // add right column list items
+      $(proxyInfoRightColumnDiv)
+        .append(createInfoLi('Total slots used', node.totalUsed))
+        .append(createInfoLi('Max concurrent slots', node.configuration.maxSession))
+        .append(createInfoLi('Total sessions started', node.totalSessionsStarted, '', true))
+        .append(createInfoLi('Total sessions complete', node.totalSessionsComplete, '', true))
+        .append(createInfoLi('Register cycle', node.configuration.registerCycle, 'ms', false))
+        .append(createInfoLi('Cleanup cycle', node.configuration.cleanUpCycle, 'ms', false));
+      $(proxyInfoRightColumnDiv).appendTo(proxyInfoDiv);
+
+      //slot usage
+      $(proxyInfoDiv).append('<br>').append(addSlotInfo(node.slotUsage));
+
+      //proxy info row
+      $(proxyDiv).append(proxyInfoDiv);
+
+      //add a line break content
+      $(proxyDiv).append('<br>');
+    });
+
+    //add the proxy div to content
+    $(proxyDiv).appendTo('#content');
+    $(this).trigger('updateIcons');
+  });
+
+}());

--- a/server/src/main/resources/form/view.css
+++ b/server/src/main/resources/form/view.css
@@ -1,865 +1,786 @@
-body
-{
-	background:#fffff;
-	font-family:"Lucida Grande", Tahoma, Arial, Verdana, sans-serif;
-	font-size:small;
-	margin:8px 0 16px;
-	text-align:center;
+body {
+  background: #fffff;
+  font-family: "Lucida Grande", Tahoma, Arial, Verdana, sans-serif;
+  font-size: small;
+  margin: 8px 0 16px;
+  text-align: center;
 }
 
-#form_container
-{
-	background:#fff;
-	border:1px solid #ccc;
-	margin:0 auto;
-	text-align:left;
-	width:640px;
+#form_container {
+  background: #fff;
+  border: 1px solid #ccc;
+  margin: 0 auto;
+  text-align: left;
+  width: 640px;
 }
 
-#top
-{
-	display:block;
-	height:10px;
-	margin:10px auto 0;
-	width:650px;
+#top {
+  display: block;
+  height: 10px;
+  margin: 10px auto 0;
+  width: 650px;
 }
 
-#footer
-{
-	width:640px;
-	clear:both;
-	color:#999999;
-	text-align:center;
-	width:640px;
-	padding-bottom: 15px;
-	font-size: 85%;
+#footer {
+  width: 640px;
+  clear: both;
+  color: #999999;
+  text-align: center;
+  width: 640px;
+  padding-bottom: 15px;
+  font-size: 85%;
 }
 
-#footer a{
-	color:#999999;
-	text-decoration: none;
-	border-bottom: 1px dotted #999999;
+#footer a {
+  color: #999999;
+  text-decoration: none;
+  border-bottom: 1px dotted #999999;
 }
 
-#bottom
-{
-	display:block;
-	height:10px;
-	margin:0 auto;
-	width:650px;
+#bottom {
+  display: block;
+  height: 10px;
+  margin: 0 auto;
+  width: 650px;
 }
 
-form.appnitro
-{
-	margin:20px 20px 0;
-	padding:0 0 20px;
+form.appnitro {
+  margin: 20px 20px 0;
+  padding: 0 0 20px;
 }
 
 /**** Logo Section  *****/
-h1
-{
-	background-color:#dedede;
-	margin:0;
-	min-height:0;
-	padding:0;
-	text-decoration:none;
-	text-indent:-8000px;
-	
+h1 {
+  background-color: #dedede;
+  margin: 0;
+  min-height: 0;
+  padding: 0;
+  text-decoration: none;
+  text-indent: -8000px;
+
 }
 
-h1 a
-{
-	
-	display:block;
-	height:100%;
-	min-height:40px;
-	overflow:hidden;
+h1 a {
+
+  display: block;
+  height: 100%;
+  min-height: 40px;
+  overflow: hidden;
 }
 
-img
-{
-	behavior:url(../../../form/iepngfix.htc);
-	border:none;
+img {
+  behavior: url(../../../form/iepngfix.htc);
+  border: none;
 }
-
 
 /**** Form Section ****/
-.appnitro
-{
-	font-family:Lucida Grande, Tahoma, Arial, Verdana, sans-serif;
-	font-size:small;
+.appnitro {
+  font-family: Lucida Grande, Tahoma, Arial, Verdana, sans-serif;
+  font-size: small;
 }
 
-.appnitro li
-{
-	width:61%;
+.appnitro li {
+  width: 61%;
 }
 
-form ul
-{
-	font-size:100%;
-	list-style-type:none;
-	margin:0;
-	padding:0;
-	width:100%;
+form ul {
+  font-size: 100%;
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+  width: 100%;
 }
 
-form li
-{
-	display:block;
-	margin:0;
-	padding:4px 5px 2px 9px;
-	position:relative;
+form li {
+  display: block;
+  margin: 0;
+  padding: 4px 5px 2px 9px;
+  position: relative;
 }
 
-form li:after
-{
-	clear:both;
-	content:".";
-	display:block;
-	height:0;
-	visibility:hidden;
+form li:after {
+  clear: both;
+  content: ".";
+  display: block;
+  height: 0;
+  visibility: hidden;
 }
 
-.buttons:after
-{
-	clear:both;
-	content:".";
-	display:block;
-	height:0;
-	visibility:hidden;
+.buttons:after {
+  clear: both;
+  content: ".";
+  display: block;
+  height: 0;
+  visibility: hidden;
 }
 
-.buttons
-{
-	clear:both;
-	display:block;
-	margin-top:10px;
+.buttons {
+  clear: both;
+  display: block;
+  margin-top: 10px;
 }
 
-* html form li
-{
-	height:1%;
+* html form li {
+  height: 1%;
 }
 
-* html .buttons
-{
-	height:1%;
+* html .buttons {
+  height: 1%;
 }
 
-* html form li div
-{
-	display:inline-block;
+* html form li div {
+  display: inline-block;
 }
 
-form li div
-{
-	color:#444;
-	margin:0 4px 0 0;
-	padding:0 0 8px;
+form li div {
+  color: #444;
+  margin: 0 4px 0 0;
+  padding: 0 0 8px;
 }
 
-form li span
-{
-	color:#444;
-	float:left;
-	margin:0 4px 0 0;
-	padding:0 0 8px;
+form li span {
+  color: #444;
+  float: left;
+  margin: 0 4px 0 0;
+  padding: 0 0 8px;
 }
 
-form li div.left
-{
-	display:inline;
-	float:left;
-	width:48%;
+form li div.left {
+  display: inline;
+  float: left;
+  width: 48%;
 }
 
-form li div.right
-{
-	display:inline;
-	float:right;
-	width:48%;
+form li div.right {
+  display: inline;
+  float: right;
+  width: 48%;
 }
 
-form li div.left .medium
-{
-	width:100%;
+form li div.left .medium {
+  width: 100%;
 }
 
-form li div.right .medium
-{
-	width:100%;
+form li div.right .medium {
+  width: 100%;
 }
 
-.clear
-{
-	clear:both;
+.clear {
+  clear: both;
 }
 
-form li div label
-{
-	clear:both;
-	color:#444444;
-	display:block;
-	font-size:9px;
-	line-height:9px;
-	margin:0;
-	padding-top:3px;
+form li div label {
+  clear: both;
+  color: #444444;
+  display: block;
+  font-size: 9px;
+  line-height: 9px;
+  margin: 0;
+  padding-top: 3px;
 }
 
-form li span label
-{
-	clear:both;
-	color:#444444;
-	display:block;
-	font-size:9px;
-	line-height:9px;
-	margin:0;
-	padding-top:3px;
+form li span label {
+  clear: both;
+  color: #444444;
+  display: block;
+  font-size: 9px;
+  line-height: 9px;
+  margin: 0;
+  padding-top: 3px;
 }
 
-form li .datepicker
-{
-	cursor:pointer !important;
-	float:left;
-	height:16px;
-	margin:.1em 5px 0 0;
-	padding:0;
-	width:16px;
+form li .datepicker {
+  cursor: pointer !important;
+  float: left;
+  height: 16px;
+  margin: .1em 5px 0 0;
+  padding: 0;
+  width: 16px;
 }
 
-.form_description
-{
-	border-bottom:1px dotted #ccc;
-	clear:both;
-	display:inline-block;
-	margin:0 0 1em;
+.form_description {
+  border-bottom: 1px dotted #ccc;
+  clear: both;
+  display: inline-block;
+  margin: 0 0 1em;
 }
 
-.form_description[class]
-{
-	display:block;
+.form_description[class] {
+  display: block;
 }
 
-.form_description h2
-{
-	clear:left;
-	font-size:160%;
-	font-weight:400;
-	margin:0 0 3px;
+.form_description h2 {
+  clear: left;
+  font-size: 160%;
+  font-weight: 400;
+  margin: 0 0 3px;
 }
 
-.form_description p
-{
-	font-size:95%;
-	line-height:130%;
-	margin:0 0 12px;
+.form_description p {
+  font-size: 95%;
+  line-height: 130%;
+  margin: 0 0 12px;
 }
 
-form hr
-{
-	display:none;
+form hr {
+  display: none;
 }
 
-form li.section_break
-{
-	border-top:1px dotted #ccc;
-	margin-top:9px;
-	padding-bottom:0;
-	padding-left:9px;
-	padding-top:13px;
-	width:97% !important;
+form li.section_break {
+  border-top: 1px dotted #ccc;
+  margin-top: 9px;
+  padding-bottom: 0;
+  padding-left: 9px;
+  padding-top: 13px;
+  width: 97% !important;
 }
 
-form ul li.first
-{
-	border-top:none !important;
-	margin-top:0 !important;
-	padding-top:0 !important;
+form ul li.first {
+  border-top: none !important;
+  margin-top: 0 !important;
+  padding-top: 0 !important;
 }
 
-form .section_break h3
-{
-	font-size:110%;
-	font-weight:400;
-	line-height:130%;
-	margin:0 0 2px;
+form .section_break h3 {
+  font-size: 110%;
+  font-weight: 400;
+  line-height: 130%;
+  margin: 0 0 2px;
 }
 
-form .section_break p
-{
-	font-size:85%;
+form .section_break p {
+  font-size: 85%;
 
-	margin:0 0 10px;
+  margin: 0 0 10px;
 }
 
 /**** Buttons ****/
-input.button_text
-{
-	overflow:visible;
-	padding:0 7px;
-	width:auto;
+input.button_text {
+  overflow: visible;
+  padding: 0 7px;
+  width: auto;
 }
 
-.buttons input
-{
-	font-size:120%;
-	margin-right:5px;
+.buttons input {
+  font-size: 120%;
+  margin-right: 5px;
 }
 
 /**** Inputs and Labels ****/
-label.description
-{
-	border:none;
-	color:#222;
-	display:block;
-	font-size:95%;
-	font-weight:700;
-	line-height:150%;
-	padding:0 0 1px;
+label.description {
+  border: none;
+  color: #222;
+  display: block;
+  font-size: 95%;
+  font-weight: 700;
+  line-height: 150%;
+  padding: 0 0 1px;
 }
 
-span.symbol
-{
-	font-size:115%;
-	line-height:130%;
+span.symbol {
+  font-size: 115%;
+  line-height: 130%;
 }
 
-input.text
-{
-	background:#ffffff url(../../../form/shadow.gif) repeat-x top;
-	border-bottom:1px solid #ddd;
-	border-left:1px solid #c3c3c3;
-	border-right:1px solid #c3c3c3;
-	border-top:1px solid #7c7c7c;
-	color:#333;
-	font-size:100%;
-	margin:0;
-	padding:2px 0;
+input.text {
+  background: #ffffff url(../../../form/shadow.gif) repeat-x top;
+  border-bottom: 1px solid #ddd;
+  border-left: 1px solid #c3c3c3;
+  border-right: 1px solid #c3c3c3;
+  border-top: 1px solid #7c7c7c;
+  color: #333;
+  font-size: 100%;
+  margin: 0;
+  padding: 2px 0;
 }
 
-input.file
-{
-	color:#333;
-	font-size:100%;
-	margin:0;
-	padding:2px 0;
+input.file {
+  color: #333;
+  font-size: 100%;
+  margin: 0;
+  padding: 2px 0;
 }
 
-textarea.textarea
-{
-	background:#ffffff url(../../../form/shadow.gif) repeat-x top;
-	border-bottom:1px solid #ddd;
-	border-left:1px solid #c3c3c3;
-	border-right:1px solid #c3c3c3;
-	border-top:1px solid #7c7c7c;
-	color:#333;
-	font-family:"Lucida Grande", Tahoma, Arial, Verdana, sans-serif;
-	font-size:100%;
-	margin:0;
-	width:99%;
+textarea.textarea {
+  background: #ffffff url(../../../form/shadow.gif) repeat-x top;
+  border-bottom: 1px solid #ddd;
+  border-left: 1px solid #c3c3c3;
+  border-right: 1px solid #c3c3c3;
+  border-top: 1px solid #7c7c7c;
+  color: #333;
+  font-family: "Lucida Grande", Tahoma, Arial, Verdana, sans-serif;
+  font-size: 100%;
+  margin: 0;
+  width: 99%;
 }
 
-select.select
-{
-	color:#333;
-	font-size:100%;
-	margin:1px 0;
-	padding:1px 0 0;
-	background:#ffffff url(../../../form/shadow.gif) repeat-x top;
-	border-bottom:1px solid #ddd;
-	border-left:1px solid #c3c3c3;
-	border-right:1px solid #c3c3c3;
-	border-top:1px solid #7c7c7c;
+select.select {
+  color: #333;
+  font-size: 100%;
+  margin: 1px 0;
+  padding: 1px 0 0;
+  background: #ffffff url(../../../form/shadow.gif) repeat-x top;
+  border-bottom: 1px solid #ddd;
+  border-left: 1px solid #c3c3c3;
+  border-right: 1px solid #c3c3c3;
+  border-top: 1px solid #7c7c7c;
 }
 
-
-input.currency
-{
-	text-align:right;
+input.currency {
+  text-align: right;
 }
 
-input.checkbox
-{
-	display:block;
-	height:13px;
-	line-height:1.4em;
-	margin:6px 0 0 3px;
-	width:13px;
+input.checkbox {
+  display: block;
+  height: 13px;
+  line-height: 1.4em;
+  margin: 6px 0 0 3px;
+  width: 13px;
 }
 
-input.radio
-{
-	display:block;
-	height:13px;
-	line-height:1.4em;
-	margin:6px 0 0 3px;
-	width:13px;
+input.radio {
+  display: block;
+  height: 13px;
+  line-height: 1.4em;
+  margin: 6px 0 0 3px;
+  width: 13px;
 }
 
-label.choice
-{
-	color:#444;
-	display:block;
-	font-size:100%;
-	line-height:1.4em;
-	margin:-1.55em 0 0 25px;
-	padding:4px 0 5px;
-	width:90%;
+label.choice {
+  color: #444;
+  display: block;
+  font-size: 100%;
+  line-height: 1.4em;
+  margin: -1.55em 0 0 25px;
+  padding: 4px 0 5px;
+  width: 90%;
 }
 
-select.select[class]
-{
-	margin:0;
-	padding:1px 0;
+select.select[class] {
+  margin: 0;
+  padding: 1px 0;
 }
 
-*:first-child+html select.select[class]
-{
-	margin:1px 0;
+*:first-child + html select.select[class] {
+  margin: 1px 0;
 }
 
-.safari select.select
-{
-	font-size:120% !important;
-	margin-bottom:1px;
+.safari select.select {
+  font-size: 120% !important;
+  margin-bottom: 1px;
 }
 
-input.small
-{
-	width:25%;
+input.small {
+  width: 25%;
 }
 
-select.small
-{
-	width:25%;
+select.small {
+  width: 25%;
 }
 
-input.medium
-{
-	width:50%;
+input.medium {
+  width: 50%;
 }
 
-select.medium
-{
-	width:50%;
+select.medium {
+  width: 50%;
 }
 
-input.large
-{
-	width:99%;
+input.large {
+  width: 99%;
 }
 
-select.large
-{
-	width:100%;
+select.large {
+  width: 100%;
 }
 
-textarea.small
-{
-	height:5.5em;
+textarea.small {
+  height: 5.5em;
 }
 
-textarea.medium
-{
-	height:10em;
+textarea.medium {
+  height: 10em;
 }
 
-textarea.large
-{
-	height:20em;
+textarea.large {
+  height: 20em;
 }
 
 /**** Errors ****/
-#error_message
-{
-	background:#fff;
-	border:1px dotted red;
-	margin-bottom:1em;
-	padding-left:0;
-	padding-right:0;
-	padding-top:4px;
-	text-align:center;
-	width:99%;
+#error_message {
+  background: #fff;
+  border: 1px dotted red;
+  margin-bottom: 1em;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 4px;
+  text-align: center;
+  width: 99%;
 }
 
-#error_message_title
-{
-	color:#DF0000;
-	font-size:125%;
-	margin:7px 0 5px;
-	padding:0;
+#error_message_title {
+  color: #DF0000;
+  font-size: 125%;
+  margin: 7px 0 5px;
+  padding: 0;
 }
 
-#error_message_desc
-{
-	color:#000;
-	font-size:100%;
-	margin:0 0 .8em;
+#error_message_desc {
+  color: #000;
+  font-size: 100%;
+  margin: 0 0 .8em;
 }
 
-#error_message_desc strong
-{
-	background-color:#FFDFDF;
-	color:red;
-	padding:2px 3px;
+#error_message_desc strong {
+  background-color: #FFDFDF;
+  color: red;
+  padding: 2px 3px;
 }
 
-form li.error
-{
-	background-color:#FFDFDF !important;
-	border-bottom:1px solid #EACBCC;
-	border-right:1px solid #EACBCC;
-	margin:3px 0;
+form li.error {
+  background-color: #FFDFDF !important;
+  border-bottom: 1px solid #EACBCC;
+  border-right: 1px solid #EACBCC;
+  margin: 3px 0;
 }
 
-form li.error label
-{
-	color:#DF0000 !important;
+form li.error label {
+  color: #DF0000 !important;
 }
 
-form p.error
-{
-	clear:both;
-	color:red;
-	font-size:10px;
-	font-weight:700;
-	margin:0 0 5px;
+form p.error, p.error {
+  clear: both;
+  color: red;
+  font-size: 10px;
+  font-weight: 700;
+  margin: 0 0 5px;
 }
 
-form .required
-{
-	color:red;
-	float:none;
-	font-weight:700;
+form .required {
+  color: red;
+  float: none;
+  font-weight: 700;
 }
 
 /**** Guidelines and Error Highlight ****/
-form li.highlighted
-{
-	background-color:#fff7c0;
+form li.highlighted {
+  background-color: #fff7c0;
 }
 
-form .guidelines
-{
-	background:#f5f5f5;
-	border:1px solid #e6e6e6;
-	color:#444;
-	font-size:80%;
-	left:100%;
-	line-height:130%;
-	margin:0 0 0 8px;
-	padding:8px 10px 9px;
-	position:absolute;
-	top:0;
-	visibility:hidden;
-	width:42%;
-	z-index:1000;
+form .guidelines {
+  background: #f5f5f5;
+  border: 1px solid #e6e6e6;
+  color: #444;
+  font-size: 80%;
+  left: 100%;
+  line-height: 130%;
+  margin: 0 0 0 8px;
+  padding: 8px 10px 9px;
+  position: absolute;
+  top: 0;
+  visibility: hidden;
+  width: 42%;
+  z-index: 1000;
 }
 
-form .guidelines small
-{
-	font-size:105%;
+form .guidelines small {
+  font-size: 105%;
 }
 
-form li.highlighted .guidelines
-{
-	visibility:visible;
+form li.highlighted .guidelines {
+  visibility: visible;
 }
 
-form li:hover .guidelines
-{
-	visibility:visible;
+form li:hover .guidelines {
+  visibility: visible;
 }
 
-.no_guidelines .guidelines
-{
-	display:none !important;
+.no_guidelines .guidelines {
+  display: none !important;
 }
 
-.no_guidelines form li
-{
-	width:97%;
+.no_guidelines form li {
+  width: 97%;
 }
 
-.no_guidelines li.section
-{
-	padding-left:9px;
+.no_guidelines li.section {
+  padding-left: 9px;
 }
 
 /*** Success Message ****/
-.form_success 
-{
-	clear: both;
-	margin: 0;
-	padding: 90px 0pt 100px;
-	text-align: center
+.form_success {
+  clear: both;
+  margin: 0;
+  padding: 90px 0pt 100px;
+  text-align: center
 }
 
 .form_success h2 {
-    clear:left;
-    font-size:160%;
-    font-weight:normal;
-    margin:0pt 0pt 3px;
+  clear: left;
+  font-size: 160%;
+  font-weight: normal;
+  margin: 0pt 0pt 3px;
 }
 
 /*** Password ****/
 
-ul.password{
-    margin-top:60px;
-    margin-bottom: 60px;
-    text-align: center;
+ul.password {
+  margin-top: 60px;
+  margin-bottom: 60px;
+  text-align: center;
 }
-.password h2{
-    color:#DF0000;
-    font-weight:bold;
-    margin:0pt auto 10px;
+
+.password h2 {
+  color: #DF0000;
+  font-weight: bold;
+  margin: 0pt auto 10px;
 }
 
 .password input.text {
-   font-size:170% !important;
-   width:380px;
-   text-align: center;
-}
-.password label{
-   display:block;
-   font-size:120% !important;
-   padding-top:10px;
-   font-weight:bold;
+  font-size: 170% !important;
+  width: 380px;
+  text-align: center;
 }
 
-#li_captcha{
-   padding-left: 5px;
+.password label {
+  display: block;
+  font-size: 120% !important;
+  padding-top: 10px;
+  font-weight: bold;
 }
 
+#li_captcha {
+  padding-left: 5px;
+}
 
-#li_captcha span{
-	float:none;
+#li_captcha span {
+  float: none;
 }
 
 /** Embedded Form **/
 
-.embed #form_container{
-	border: none;
+.embed #form_container {
+  border: none;
 }
 
-.embed #top, .embed #bottom, .embed h1{
-	display: none;
+.embed #top, .embed #bottom, .embed h1 {
+  display: none;
 }
 
-.embed #form_container{
-	width: 100%;
+.embed #form_container {
+  width: 100%;
 }
 
-.embed #footer{
-	text-align: left;
-	padding-left: 10px;
-	width: 99%;
+.embed #footer {
+  text-align: left;
+  padding-left: 10px;
+  width: 99%;
 }
 
-.embed #footer.success{
-	text-align: center;
+.embed #footer.success {
+  text-align: center;
 }
 
-.embed form.appnitro
-{
-	margin:0px 0px 0;
-	
+.embed form.appnitro {
+  margin: 0px 0px 0;
+
 }
-
-
 
 /*** Calendar **********************/
-div.calendar { position: relative; }
-
-.calendar table {
-cursor:pointer;
-border:1px solid #ccc;
-font-size: 11px;
-color: #000;
-background: #fff;
-font-family:"Lucida Grande", Tahoma, Arial, Verdana, sans-serif;
+div.calendar {
+  position: relative;
 }
 
-.calendar .button { 
-text-align: center;    
-padding: 2px;          
+.calendar table {
+  cursor: pointer;
+  border: 1px solid #ccc;
+  font-size: 11px;
+  color: #000;
+  background: #fff;
+  font-family: "Lucida Grande", Tahoma, Arial, Verdana, sans-serif;
+}
+
+.calendar .button {
+  text-align: center;
+  padding: 2px;
 }
 
 .calendar .nav {
-background:#f5f5f5;
+  background: #f5f5f5;
 }
 
-.calendar thead .title { 
-font-weight: bold;      
-text-align: center;
-background: #dedede;
-color: #000;
-padding: 2px 0 3px 0;
+.calendar thead .title {
+  font-weight: bold;
+  text-align: center;
+  background: #dedede;
+  color: #000;
+  padding: 2px 0 3px 0;
 }
 
-.calendar thead .headrow { 
-background: #f5f5f5;
-color: #444;
-font-weight:bold;
+.calendar thead .headrow {
+  background: #f5f5f5;
+  color: #444;
+  font-weight: bold;
 }
 
-.calendar thead .daynames { 
-background: #fff;
-color:#333;
-font-weight:bold;
+.calendar thead .daynames {
+  background: #fff;
+  color: #333;
+  font-weight: bold;
 }
 
-.calendar thead .name { 
-border-bottom: 1px dotted #ccc;
-padding: 2px;
-text-align: center;
-color: #000;
+.calendar thead .name {
+  border-bottom: 1px dotted #ccc;
+  padding: 2px;
+  text-align: center;
+  color: #000;
 }
 
-.calendar thead .weekend { 
-color: #666;
+.calendar thead .weekend {
+  color: #666;
 }
 
-.calendar thead .hilite { 
-background-color: #444;
-color: #fff;
-padding: 1px;
+.calendar thead .hilite {
+  background-color: #444;
+  color: #fff;
+  padding: 1px;
 }
 
-.calendar thead .active { 
-background-color: #d12f19;
-color:#fff;
-padding: 2px 0px 0px 2px;
+.calendar thead .active {
+  background-color: #d12f19;
+  color: #fff;
+  padding: 2px 0px 0px 2px;
 }
 
-
-.calendar tbody .day { 
-width:1.8em;
-color: #222;
-text-align: right;
-padding: 2px 2px 2px 2px;
+.calendar tbody .day {
+  width: 1.8em;
+  color: #222;
+  text-align: right;
+  padding: 2px 2px 2px 2px;
 }
+
 .calendar tbody .day.othermonth {
-font-size: 80%;
-color: #bbb;
+  font-size: 80%;
+  color: #bbb;
 }
+
 .calendar tbody .day.othermonth.oweekend {
-color: #fbb;
+  color: #fbb;
 }
 
 .calendar table .wn {
-padding: 2px 2px 2px 2px;
-border-right: 1px solid #000;
-background: #666;
+  padding: 2px 2px 2px 2px;
+  border-right: 1px solid #000;
+  background: #666;
 }
 
 .calendar tbody .rowhilite td {
-background: #FFF1AF;
+  background: #FFF1AF;
 }
 
 .calendar tbody .rowhilite td.wn {
-background: #FFF1AF;
+  background: #FFF1AF;
 }
 
-.calendar tbody td.hilite { 
-padding: 1px 1px 1px 1px;
-background:#444 !important;
-color:#fff !important;
+.calendar tbody td.hilite {
+  padding: 1px 1px 1px 1px;
+  background: #444 !important;
+  color: #fff !important;
 }
 
-.calendar tbody td.active { 
-color:#fff;
-background: #529214 !important;
-padding: 2px 2px 0px 2px;
+.calendar tbody td.active {
+  color: #fff;
+  background: #529214 !important;
+  padding: 2px 2px 0px 2px;
 }
 
-.calendar tbody td.selected { 
-font-weight: bold;
-border: 1px solid #888;
-padding: 1px 1px 1px 1px;
-background: #f5f5f5 !important;
-color: #222 !important;
+.calendar tbody td.selected {
+  font-weight: bold;
+  border: 1px solid #888;
+  padding: 1px 1px 1px 1px;
+  background: #f5f5f5 !important;
+  color: #222 !important;
 }
 
-.calendar tbody td.weekend { 
-color: #666;
+.calendar tbody td.weekend {
+  color: #666;
 }
 
-.calendar tbody td.today { 
-font-weight: bold;
-color: #529214;
-background:#D9EFC2;
+.calendar tbody td.today {
+  font-weight: bold;
+  color: #529214;
+  background: #D9EFC2;
 }
 
-.calendar tbody .disabled { color: #999; }
-
-.calendar tbody .emptycell { 
-visibility: hidden;
+.calendar tbody .disabled {
+  color: #999;
 }
 
-.calendar tbody .emptyrow { 
-display: none;
+.calendar tbody .emptycell {
+  visibility: hidden;
 }
 
-.calendar tfoot .footrow { 
-text-align: center;
-background: #556;
-color: #fff;
+.calendar tbody .emptyrow {
+  display: none;
 }
 
-.calendar tfoot .ttip { 
-background: #222;
-color: #fff;
-font-size:10px;
-border-top: 1px solid #dedede;
-padding: 3px;
+.calendar tfoot .footrow {
+  text-align: center;
+  background: #556;
+  color: #fff;
 }
 
-.calendar tfoot .hilite { 
-background: #aaf;
-border: 1px solid #04f;
-color: #000;
-padding: 1px;
+.calendar tfoot .ttip {
+  background: #222;
+  color: #fff;
+  font-size: 10px;
+  border-top: 1px solid #dedede;
+  padding: 3px;
 }
 
-.calendar tfoot .active { 
-background: #77c;
-padding: 2px 0px 0px 2px;
+.calendar tfoot .hilite {
+  background: #aaf;
+  border: 1px solid #04f;
+  color: #000;
+  padding: 1px;
+}
+
+.calendar tfoot .active {
+  background: #77c;
+  padding: 2px 0px 0px 2px;
 }
 
 .calendar .combo {
-position: absolute;
-display: none;
-top: 0px;
-left: 0px;
-width: 4em;
-border: 1px solid #ccc;
-background: #f5f5f5;
-color: #222;
-font-size: 90%;
-z-index: 100;
+  position: absolute;
+  display: none;
+  top: 0px;
+  left: 0px;
+  width: 4em;
+  border: 1px solid #ccc;
+  background: #f5f5f5;
+  color: #222;
+  font-size: 90%;
+  z-index: 100;
 }
 
 .calendar .combo .label,
 .calendar .combo .label-IEfix {
-text-align: center;
-padding: 1px;
+  text-align: center;
+  padding: 1px;
 }
 
 .calendar .combo .label-IEfix {
-width: 4em;
+  width: 4em;
 }
 
 .calendar .combo .hilite {
-background: #444;
-color:#fff;
+  background: #444;
+  color: #fff;
 }
 
 .calendar .combo .active {
-border-top: 1px solid #999;
-border-bottom: 1px solid #999;
-background: #dedede;
-font-weight: bold;
+  border-top: 1px solid #999;
+  border-bottom: 1px solid #999;
+  background: #dedede;
+  font-weight: bold;
 }
-


### PR DESCRIPTION
- `ListAllNodes` will now return `application/json` when the header `"Accept:
  application/json"` is present
- Improve `ListAllNodes` `text/html`view to;
  - Display more node information
  - Display information which is applicable to nodes which use
    SeLionRemoteProxy such as `uniqueSessionCount` and more
  - Optionally ping the node for /status when the query param `?pingNodes`
    is present
  - Render view from embedded JSON output -- which is the same output
    ListAllNodes returns if the request is for a JSON only response
- Misc changes including;
  - Remove RESOURCE_PAGE_FILE related constants from `SeLionGridConstants`
  - Remove tabs from view.css
  - `SeLionRemoteProxy` now pings the node at initialization to determine
    if it supports SeLion servlets that are needed for key capabilities
    such as 'auto upgrade' and 'restart'. Methods added to get the
    result of the findings.
  - Other misc informational / state related methods added to `SeLionRemoteProxy`
  - Fix potential NPE in `AuthenticationHelper` which occurred client
    session is active but server was restarted.
  - Introduce `respondAsHtmlUsingJsonAndTemplateWithHttpStatus` in
    ServletHelper.java
  - Introduce new resource path for servlets `/com/paypal/selion/*` which
    is more inline with selenium-server's pattern -- all SeLion servlets
    to follow suit eventually

Screenshot of updated `ListAllNodes` responding with `text/html`
![image](https://cloud.githubusercontent.com/assets/3238999/10859307/7dfd632e-7f19-11e5-82f9-d607b8263be7.png)

Example of updated ListAllNodes servlet responding with `application/json`

``` json
[{
    "logsLocation": "http://127.0.0.1:5555/extra/LogServlet",
    "isBusy": false,
    "percentResourceUsage": 0.0,
    "totalUsed": 0,
    "isShuttingDown": false,
    "totalSessionsComplete": 0,
    "totalSessionsStarted": 0,
    "uptimeInMinutes": 7,
    "configuration": {
        "port": 5555,
        "nodeConfig": "/Users/dsimmons/.selion/config/nodeConfig.json",
        "hubConfig": "/Users/dsimmons/.selion/config/hubConfig.json",
        "registerCycle": 300000,
        "newSessionWaitTimeout": -1,
        "prioritizer": null,
        "remoteHost": "http://127.0.0.1:5555",
        "throwOnCapabilityNotPresent": true,
        "proxy": "com.paypal.selion.proxy.SeLionRemoteProxy",
        "maxSession": 20,
        "role": "node",
        "uniqueSessionCount": 50,
        "host": "127.0.0.1",
        "servlets": "com.paypal.selion.node.servlets.LogServlet,com.paypal.selion.node.servlets.NodeAutoUpgradeServlet,com.paypal.selion.node.servlets.NodeForceRestartServlet",
        "cleanUpCycle": 30000,
        "browserTimeout": 180000,
        "selionConfig": "/Users/dsimmons/.selion/config/SeLionConfig.json",
        "hubHost": "127.0.0.1",
        "capabilityMatcher": "com.paypal.selion.grid.matchers.MobileCapabilityMatcher",
        "url": "http://127.0.0.1:5555",
        "nodeRecycleThreadWaitTimeout": 0,
        "register": true,
        "nodePolling": 5000,
        "jettyMaxThreads": -1,
        "hubPort": 4444,
        "timeout": 120000
    },
    "status": "online",
    "version": "2.47.1",
    "os": "Mac OS X 10.10.5",
    "slotUsage": {
        "firefox": {
            "used": 0,
            "percentUsed": 0,
            "maxInstances": 15
        },
        "chrome": {
            "used": 0,
            "percentUsed": 0,
            "maxInstances": 10
        },
        "phantomjs": {
            "used": 0,
            "percentUsed": 0,
            "maxInstances": 10
        }
    }
}]
```
