### PR TITLE
Fixed coding standard issues

### DIFF
--- a/client/src/main/java/com/paypal/selion/configuration/ListenerManager.java
+++ b/client/src/main/java/com/paypal/selion/configuration/ListenerManager.java
@@ -118,7 +118,7 @@ public final class ListenerManager {
     }
 
     private static boolean isServiceLoaderDisabled() {
-        return serviceLoaderEnabled == false;
+        return !serviceLoaderEnabled;
     }
 
 }

--- a/client/src/main/java/com/paypal/selion/internal/platform/grid/LocalNode.java
+++ b/client/src/main/java/com/paypal/selion/internal/platform/grid/LocalNode.java
@@ -148,10 +148,7 @@ final class LocalNode extends AbstractBaseLocalServerComponent {
             // check the CWD and PATH for the driverBinary
             @SuppressWarnings("deprecation")
             String location = CommandLine.find(driverBinary.replace(".exe", ""));
-            if (location != null) {
-                return true;
-            }
-            return false;
+            return (location != null);
         }
         return true;
     }

--- a/client/src/main/java/com/paypal/selion/internal/platform/grid/MobileTestSession.java
+++ b/client/src/main/java/com/paypal/selion/internal/platform/grid/MobileTestSession.java
@@ -244,11 +244,7 @@ public class MobileTestSession extends AbstractTestSession {
     }
 
     private boolean isDeviceDefined() {
-        if (device.contains("android") || device.contains("iphone") || device.contains("ipad")) {
-            return true;
-        } else {
-            return false;
-        }
+        return (device.contains("android") || device.contains("iphone") || device.contains("ipad"));
     }
 
 

--- a/client/src/main/java/com/paypal/selion/internal/platform/grid/SeleniumGridListener.java
+++ b/client/src/main/java/com/paypal/selion/internal/platform/grid/SeleniumGridListener.java
@@ -155,10 +155,7 @@ public class SeleniumGridListener implements IInvokedMethodListener, ISuiteListe
         if (method.isTestMethod()) {
             return true;
         }
-        if (method.getTestMethod().isBeforeClassConfiguration()) {
-            return true;
-        }
-        return false;
+        return method.getTestMethod().isBeforeClassConfiguration();
     }
 
     private void testSessionSharingRules(IInvokedMethod method) {
@@ -219,11 +216,7 @@ public class SeleniumGridListener implements IInvokedMethodListener, ISuiteListe
             int parameterInvocationCount = method.getTestMethod().getParameterInvocationCount();
             // If the data set from the data provider is exhausted
             // It means its the last method with the data provider- this is the exit condition
-            if (currentInvocationCount == parameterInvocationCount) {
-                return true;
-            }
-            // Otherwise,keep holding on to the session
-            return false;
+            return (currentInvocationCount == parameterInvocationCount);
         }
 
         return true;

--- a/client/src/main/java/com/paypal/selion/internal/platform/grid/WebTestSession.java
+++ b/client/src/main/java/com/paypal/selion/internal/platform/grid/WebTestSession.java
@@ -41,7 +41,7 @@ public class WebTestSession extends AbstractTestSession {
     private static final SimpleLogger logger = SeLionLogger.getLogger();
 
     WebTestSession() {
-        // nothing to do
+        super();
     }
 
     /**

--- a/client/src/main/java/com/paypal/selion/internal/platform/grid/browsercapabilities/SelendroidCapabilitiesBuilder.java
+++ b/client/src/main/java/com/paypal/selion/internal/platform/grid/browsercapabilities/SelendroidCapabilitiesBuilder.java
@@ -36,29 +36,29 @@ class SelendroidCapabilitiesBuilder extends DefaultCapabilitiesBuilder {
     public DesiredCapabilities getCapabilities(DesiredCapabilities capabilities) {
 
         MobileTestSession mobileSession = Grid.getMobileTestSession();
-        capabilities = SelendroidCapabilities.android();
+        DesiredCapabilities tempCapabilities = SelendroidCapabilities.android();
 
         // check if apk exists for native app to set BrowserName to 'selendroid'
         // else set it to 'android'
         if ((new File(mobileSession.getAppLocation()).exists())
                 && ((new File(mobileSession.getAppLocation() + File.separator + mobileSession.getAppName())).exists())) {
-            capabilities.setBrowserName(SELENDROID);
+            tempCapabilities.setBrowserName(SELENDROID);
         } else {
-            capabilities.setBrowserName(ANDROID);
+            tempCapabilities.setBrowserName(ANDROID);
         }
 
-        capabilities.setCapability(MOBILE_NODE_TYPE, mobileSession.getMobileNodeType().getAsString());
-        capabilities.setCapability(SelendroidCapabilities.AUT, mobileSession.getAppName());
-        capabilities.setCapability(SelendroidCapabilities.LOCALE, mobileSession.getAppLocale());
+        tempCapabilities.setCapability(MOBILE_NODE_TYPE, mobileSession.getMobileNodeType().getAsString());
+        tempCapabilities.setCapability(SelendroidCapabilities.AUT, mobileSession.getAppName());
+        tempCapabilities.setCapability(SelendroidCapabilities.LOCALE, mobileSession.getAppLocale());
         if (StringUtils.isNotBlank(mobileSession.getDeviceType())) {
-            capabilities.setCapability(SelendroidCapabilities.MODEL, mobileSession.getDeviceType());
+            tempCapabilities.setCapability(SelendroidCapabilities.MODEL, mobileSession.getDeviceType());
         }
         if (StringUtils.isNotBlank(mobileSession.getPlatformVersion())) {
-            capabilities.setCapability(SelendroidCapabilities.PLATFORM_VERSION, mobileSession.getPlatformVersion());
+            tempCapabilities.setCapability(SelendroidCapabilities.PLATFORM_VERSION, mobileSession.getPlatformVersion());
         }
         if (StringUtils.isNotBlank(mobileSession.getdeviceSerial())) {
-            capabilities.setCapability(SelendroidCapabilities.SERIAL, mobileSession.getdeviceSerial());
+            tempCapabilities.setCapability(SelendroidCapabilities.SERIAL, mobileSession.getdeviceSerial());
         }
-        return capabilities;
+        return tempCapabilities;
     }
 }

--- a/client/src/main/java/com/paypal/selion/internal/reports/excelreport/DetailsReport.java
+++ b/client/src/main/java/com/paypal/selion/internal/reports/excelreport/DetailsReport.java
@@ -65,14 +65,14 @@ public class DetailsReport extends BaseReport<List<String>> {
         HSSFRow row;
         // Overriding style for Details Reports, as these do not have counts.
         // The details content are the test logs and stack trace.
-        style = Styles.getStyleBorderThinLeftTop();
+        HSSFCellStyle tempStyle = Styles.getStyleBorderThinLeftTop();
 
         for (List<String> dataString : this.getLstEntities()) {
             row = sheet.createRow(rowNum);
             int iColNum = getStartColNum();
             for (int i = 0; i < this.getColTitles().size(); i++) {
                 row.createCell(iColNum);
-                row.getCell(iColNum).setCellStyle(style);
+                row.getCell(iColNum).setCellStyle(tempStyle);
 
                 // Displaying time after converting to minutes
                 if (this.getColTitles().get(i).contains("Time")) {
@@ -87,7 +87,7 @@ public class DetailsReport extends BaseReport<List<String>> {
                     row.getCell(iColNum).setHyperlink(link);
                 }
                 else {
-                    row.getCell(iColNum).setCellStyle(style);
+                    row.getCell(iColNum).setCellStyle(tempStyle);
                     row.getCell(iColNum).setCellValue(dataString.get(i));
                 }
                 sheet.autoSizeColumn(iColNum++);

--- a/client/src/main/java/com/paypal/selion/internal/reports/html/CollectionSplitter.java
+++ b/client/src/main/java/com/paypal/selion/internal/reports/html/CollectionSplitter.java
@@ -35,7 +35,7 @@ public abstract class CollectionSplitter {
 
     private ISuite suite;
     private Filter filter;
-    private Map<String, Line> lineById = new HashMap<>();
+    private final Map<String, Line> lineById = new HashMap<>();
     private int totalInstancePassed;
     private int totalInstancePassedEnvt;
     private int totalInstanceFailed;

--- a/client/src/main/java/com/paypal/selion/platform/html/support/ByOrOperator.java
+++ b/client/src/main/java/com/paypal/selion/platform/html/support/ByOrOperator.java
@@ -33,6 +33,7 @@ public class ByOrOperator extends By {
     private final List<By> bys;
 
     public ByOrOperator(List<By> bys) {
+        super();
         this.bys = bys;
     }
 

--- a/client/src/main/java/com/paypal/selion/platform/html/support/HtmlElementUtils.java
+++ b/client/src/main/java/com/paypal/selion/platform/html/support/HtmlElementUtils.java
@@ -189,38 +189,38 @@ public class HtmlElementUtils {
         logger.entering(locator);
         Preconditions.checkArgument(StringUtils.isNotBlank(locator), INVALID_LOCATOR_ERR_MSG);
         By valueToReturn = null;
-        locator = locator.trim();
-        int typeDelimiterIndex = locator.indexOf('=');
-        String locatorType = typeDelimiterIndex != -1 ? locator.substring(0, typeDelimiterIndex) : locator;
+        String seleniumLocator = locator.trim();
+        int typeDelimiterIndex = seleniumLocator.indexOf('=');
+        String locatorType = typeDelimiterIndex != -1 ? seleniumLocator.substring(0, typeDelimiterIndex) : seleniumLocator;
         switch (locatorType) {
         case "id":
-            valueToReturn = By.id(locator.substring(typeDelimiterIndex + 1));
+            valueToReturn = By.id(seleniumLocator.substring(typeDelimiterIndex + 1));
             break;
         case "name":
-            valueToReturn = By.name(locator.substring(typeDelimiterIndex + 1));
+            valueToReturn = By.name(seleniumLocator.substring(typeDelimiterIndex + 1));
             break;
         case "link":
-            valueToReturn = By.linkText(locator.substring(typeDelimiterIndex + 1));
+            valueToReturn = By.linkText(seleniumLocator.substring(typeDelimiterIndex + 1));
             break;
         case "xpath":
-            valueToReturn = By.xpath(locator.substring(typeDelimiterIndex + 1));
+            valueToReturn = By.xpath(seleniumLocator.substring(typeDelimiterIndex + 1));
             break;
         case "css":
-            valueToReturn = By.cssSelector(locator.substring(typeDelimiterIndex + 1));
+            valueToReturn = By.cssSelector(seleniumLocator.substring(typeDelimiterIndex + 1));
             break;
         case "classname":
-            valueToReturn = By.className(locator.substring(typeDelimiterIndex + 1));
+            valueToReturn = By.className(seleniumLocator.substring(typeDelimiterIndex + 1));
             break;
         default:
-            if (locator.startsWith("/") || locator.startsWith("./")) {
-                valueToReturn = By.xpath(locator);
+            if (seleniumLocator.startsWith("/") || seleniumLocator.startsWith("./")) {
+                valueToReturn = By.xpath(seleniumLocator);
                 break;
             }
-            valueToReturn = new ByIdOrName(locator);
+            valueToReturn = new ByIdOrName(seleniumLocator);
         }
         if (logger.isLoggable(Level.FINE)) {
             String msg = valueToReturn.getClass().getSimpleName()
-                    + " will be the location strategy that will be used for locating " + locator;
+                    + " will be the location strategy that will be used for locating " + seleniumLocator;
             logger.log(Level.FINE, msg);
         }
         logger.exiting(valueToReturn);

--- a/client/src/main/java/com/paypal/selion/platform/mobile/ios/UIAPicker.java
+++ b/client/src/main/java/com/paypal/selion/platform/mobile/ios/UIAPicker.java
@@ -74,8 +74,8 @@ public class UIAPicker extends UIAElement implements UIAutomationPicker {
     private List<String> asList(String allValues) {
         List<String> valuesList = Collections.emptyList();
         if (!StringUtils.isBlank(allValues)) {
-            allValues = allValues.trim().substring(1, allValues.length() - 1);
-            valuesList = Arrays.asList(allValues.split("\\s*,\\s*"));
+            String tempAllValues = allValues.trim().substring(1, allValues.length() - 1);
+            valuesList = Arrays.asList(tempAllValues.split("\\s*,\\s*"));
         }
         return valuesList;
     }

--- a/client/src/test/java/com/paypal/selion/configuration/LocalConfigTest.java
+++ b/client/src/test/java/com/paypal/selion/configuration/LocalConfigTest.java
@@ -117,7 +117,7 @@ public class LocalConfigTest {
         // Ensure you've configured this test to run with browser param in suite file.
         assertTrue(!browserParam.isEmpty());
         // Drop the "* in browser and first char"
-        if (browserParam.equals("*iexplore")) {
+        if ("*iexplore".equals(browserParam)) {
             //Only for IE the user agent parsing library returns it as IE.
             assertTrue(actualBrowser.equalsIgnoreCase("ie"));
         }else {

--- a/client/src/test/java/com/paypal/selion/internal/reports/runtimereport/JsonRuntimeReporterHelperTest.java
+++ b/client/src/test/java/com/paypal/selion/internal/reports/runtimereport/JsonRuntimeReporterHelperTest.java
@@ -55,7 +55,7 @@ public class JsonRuntimeReporterHelperTest {
 
         assertEquals(completedTests.size(), 1);
         TestMethodInfo testMethod = completedTests.get(0);
-        JsonObject jsonObject = new JsonParser().parse(testMethod.toJson()).getAsJsonObject();;
+        JsonObject jsonObject = new JsonParser().parse(testMethod.toJson()).getAsJsonObject();
         assertEquals(jsonObject.get("suite").getAsString(), suiteName);
         assertEquals(jsonObject.get("test").getAsString(), testName);
         assertEquals(jsonObject.get("packageInfo").getAsString(), packageName);

--- a/client/src/test/java/com/paypal/selion/platform/html/AbstractElementTest.java
+++ b/client/src/test/java/com/paypal/selion/platform/html/AbstractElementTest.java
@@ -182,6 +182,7 @@ public class AbstractElementTest {
 
     private static class SampleSuccessPage extends BasicPageImpl {
         public SampleSuccessPage() {
+            super();
             super.initPage("paypal", "SampleSuccessPage");
         }
 
@@ -195,6 +196,7 @@ public class AbstractElementTest {
         private final HashMap<String, String> oMap = new HashMap<String, String>();
 
         SampleSuccessInMemoryPage() {
+            super();
             getPage();
         }
 

--- a/client/src/test/java/com/paypal/selion/testcomponents/GUIPageExtensionTest.java
+++ b/client/src/test/java/com/paypal/selion/testcomponents/GUIPageExtensionTest.java
@@ -40,6 +40,7 @@ public class GUIPageExtensionTest {
         private Button testButton;
 
         public SampleTestPage() {
+            super();
             super.initPage("paypal", "SampleTestPage");
         }
         

--- a/client/src/test/java/com/paypal/selion/testcomponents/TestInitializeElementsPage.java
+++ b/client/src/test/java/com/paypal/selion/testcomponents/TestInitializeElementsPage.java
@@ -60,6 +60,7 @@ public class TestInitializeElementsPage extends BasicPageImpl {
      * Creates a new TestInitializeElementsPage object
      */
     public TestInitializeElementsPage() {
+        super();
         super.initPage(PAGE_DOMAIN, CLASS_NAME);
     }
     
@@ -69,6 +70,7 @@ public class TestInitializeElementsPage extends BasicPageImpl {
      *         The Country locale for the site you are accessing
      */
     public TestInitializeElementsPage(String siteLocale) {
+        super();
         super.initPage(PAGE_DOMAIN, CLASS_NAME, siteLocale);
     }
 

--- a/client/src/test/java/com/paypal/selion/testcomponents/TestPage.java
+++ b/client/src/test/java/com/paypal/selion/testcomponents/TestPage.java
@@ -43,6 +43,7 @@ public class TestPage extends BasicPageImpl {
      * Creates a new TestPage object
      */
     public TestPage() {
+        super();
         super.initPage(PAGE_DOMAIN, CLASS_NAME);
     }
 
@@ -53,10 +54,12 @@ public class TestPage extends BasicPageImpl {
      *            The Country locale for the site you are accessing
      */
     public TestPage(String siteLocale) {
+        super();
         super.initPage(PAGE_DOMAIN, CLASS_NAME, siteLocale);
     }
 
     public TestPage(String siteLocale, String className) {
+        super();
         super.initPage(PAGE_DOMAIN, className, siteLocale);
     }
 

--- a/codegen/src/main/java/com/paypal/selion/reader/AbstractYamlReader.java
+++ b/codegen/src/main/java/com/paypal/selion/reader/AbstractYamlReader.java
@@ -91,7 +91,7 @@ public abstract class AbstractYamlReader {
             Map<String, Object> elementMap = (Map<String, Object>) element;
             try {
                 String elementKey = ((String) elementMap.get(KEY)).trim();
-                if (elementKey.equals("")) {
+                if ("".equals(elementKey)) {
                     continue;
                 }
 

--- a/codegen/src/main/java/com/paypal/selion/reader/YamlV1Reader.java
+++ b/codegen/src/main/java/com/paypal/selion/reader/YamlV1Reader.java
@@ -107,7 +107,7 @@ class YamlV1Reader extends AbstractYamlReader {
                 @SuppressWarnings("unchecked")
                 Map<String, Object> map = (Map<String, Object>) data;
                 String key = ((String) map.get(KEY)).trim();
-                if (key.equals("")) {
+                if ("".equals(key)) {
                     continue;
                 }
                 if (map.get(KEY).equals("baseClass") || map.get(KEY).equals("platform")) {

--- a/codegen/src/main/java/com/paypal/selion/reader/YamlV2Reader.java
+++ b/codegen/src/main/java/com/paypal/selion/reader/YamlV2Reader.java
@@ -43,6 +43,7 @@ class YamlV2Reader extends AbstractYamlReader {
      * @throws IOException
      */
     public YamlV2Reader(String fileName) throws IOException {
+        super();
         FileSystemResource resource = new FileSystemResource(fileName);
         processPage(resource);
     }

--- a/codegen/src/test/java/com/paypal/selion/plugins/PlatformTest.java
+++ b/codegen/src/test/java/com/paypal/selion/plugins/PlatformTest.java
@@ -15,7 +15,7 @@
 
 package com.paypal.selion.plugins;
 
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -40,14 +40,14 @@ public class PlatformTest {
     public void testWebPlatform() throws Exception {
         // When no platform is specified the default should be WEB
         TestPlatform currentPlatform = getPlatformToTest("src/test/resources/PayPalAbstractPage.yml");
-        assertTrue(currentPlatform == TestPlatform.WEB);
+        assertEquals(currentPlatform, TestPlatform.WEB);
     }
 
     @Test
     public void testIOSPlatform() throws Exception {
         // For IOS platform, the value must be specified
         TestPlatform currentPlatform = getPlatformToTest("src/test/resources/IOSInteractionPage.yaml");
-        assertTrue(currentPlatform == TestPlatform.IOS);
+        assertEquals(currentPlatform, TestPlatform.IOS);
     }
 
     @Test(expectedExceptions = { CodeGeneratorException.class })

--- a/common/src/main/java/com/paypal/test/utilities/logging/SimpleLogger.java
+++ b/common/src/main/java/com/paypal/test/utilities/logging/SimpleLogger.java
@@ -652,6 +652,7 @@ public final class SimpleLogger extends Logger implements Closeable {
         private final String identifier;
 
         public SingleLineFormatter(String identifier) {
+            super();
             this.identifier = identifier;
         }
 

--- a/dataproviders/src/main/java/com/paypal/selion/platform/dataprovider/DataProviderException.java
+++ b/dataproviders/src/main/java/com/paypal/selion/platform/dataprovider/DataProviderException.java
@@ -23,7 +23,7 @@ public class DataProviderException extends RuntimeException {
     private static final long serialVersionUID = 3290312548375984346L;
 
     public DataProviderException() {
-
+        super();
     }
 
     public DataProviderException(String message) {

--- a/dataproviders/src/main/java/com/paypal/selion/platform/dataprovider/impl/ExcelDataProviderImpl.java
+++ b/dataproviders/src/main/java/com/paypal/selion/platform/dataprovider/impl/ExcelDataProviderImpl.java
@@ -414,11 +414,12 @@ public class ExcelDataProviderImpl implements ExcelDataProvider {
      *
      */
     protected Object getSingleExcelRow(Object userObj, int index, boolean isExternalCall) {
+        int tempIndex = index;
         if (isExternalCall) {
-            index++;
+            tempIndex++;
 
         }
-        logger.entering(new Object[] { userObj, index });
+        logger.entering(new Object[] { userObj, tempIndex });
         Object obj;
 
         Class<?> cls;
@@ -429,7 +430,7 @@ public class ExcelDataProviderImpl implements ExcelDataProvider {
         }
         Field[] fields = cls.getDeclaredFields();
 
-        List<String> excelRowData = getRowContents(cls.getSimpleName(), index, fields.length);
+        List<String> excelRowData = getRowContents(cls.getSimpleName(), tempIndex, fields.length);
         if (excelRowData != null && excelRowData.size() != 0) {
             try {
                 obj = prepareObject(userObj, fields, excelRowData);
@@ -438,7 +439,7 @@ public class ExcelDataProviderImpl implements ExcelDataProvider {
                         + "'", e);
             }
         } else {
-            throw new DataProviderException("Row with key '" + index + "' is not found");
+            throw new DataProviderException("Row with key '" + tempIndex + "' is not found");
         }
 
         logger.exiting(obj);

--- a/dataproviders/src/test/java/com/paypal/selion/platform/dataprovider/JsonDataProviderTest.java
+++ b/dataproviders/src/test/java/com/paypal/selion/platform/dataprovider/JsonDataProviderTest.java
@@ -26,7 +26,6 @@ import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Iterator;
 
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import com.google.gson.internal.LinkedTreeMap;
@@ -235,7 +234,7 @@ public class JsonDataProviderTest {
         SeLionDataProvider dataProvider = DataProviderFactory.getDataProvider(resource);
         String[] keys = {"test1", "test2"};
         Object[][] dataObjects = dataProvider.getDataByKeys(keys );
-        Assert.assertNotNull(dataObjects);
-        Assert.assertEquals(dataObjects.length, 2);
+        assertNotNull(dataObjects);
+        assertEquals(dataObjects.length, 2);
     }
 }

--- a/dataproviders/src/test/java/com/paypal/selion/platform/dataprovider/XmlDataProviderTest.java
+++ b/dataproviders/src/test/java/com/paypal/selion/platform/dataprovider/XmlDataProviderTest.java
@@ -28,7 +28,6 @@ import java.util.Map;
 
 import javax.xml.xpath.XPathExpressionException;
 
-import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -167,18 +166,18 @@ public class XmlDataProviderTest {
         XmlDataSource resource = new XmlFileSystemResource(listOfKeyValuePairs, KeyValueMap.class);
         SeLionDataProvider dataProvider = DataProviderFactory.getDataProvider(resource);
         Hashtable<String, Object> data = dataProvider.getDataAsHashtable();
-        Assert.assertNotNull(data);
-        Assert.assertNotNull(data.get("k1"));
+        assertNotNull(data);
+        assertNotNull(data.get("k1"));
         KeyValuePair k1 = (KeyValuePair) data.get("k1");
-        Assert.assertNotNull(k1.getKey());
-        Assert.assertNotNull(k1.getValue());
-        Assert.assertNotNull(data.get("k2"));
+        assertNotNull(k1.getKey());
+        assertNotNull(k1.getValue());
+        assertNotNull(data.get("k2"));
         KeyValuePair k2 = (KeyValuePair) data.get("k2");
-        Assert.assertNotNull(k2.getKey());
-        Assert.assertNotNull(k2.getValue());
-        Assert.assertNotNull(data.get("k3"));
+        assertNotNull(k2.getKey());
+        assertNotNull(k2.getValue());
+        assertNotNull(data.get("k3"));
         KeyValuePair k3 = (KeyValuePair) data.get("k3");
-        Assert.assertNotNull(k3.getKey());
-        Assert.assertNotNull(k3.getValue());
+        assertNotNull(k3.getKey());
+        assertNotNull(k3.getValue());
     }
 }

--- a/dataproviders/src/test/java/com/paypal/selion/platform/dataprovider/pojos/excel/USER.java
+++ b/dataproviders/src/test/java/com/paypal/selion/platform/dataprovider/pojos/excel/USER.java
@@ -75,7 +75,7 @@ public class USER {
     }
 
     public AREA_CODE[] getAreaCode() {
-        return areaCode;
+        return Arrays.copyOf(areaCode, areaCode.length);
     }
 
     public void setAreaCode(AREA_CODE[] areaCode) {

--- a/dataproviders/src/test/java/com/paypal/selion/platform/dataprovider/pojos/xml/User.java
+++ b/dataproviders/src/test/java/com/paypal/selion/platform/dataprovider/pojos/xml/User.java
@@ -15,6 +15,8 @@
 
 package com.paypal.selion.platform.dataprovider.pojos.xml;
 
+import java.util.Arrays;
+
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -74,7 +76,7 @@ public class User {
      */
     @XmlElement(name="phoneNumber")
     public String[] getPhoneNumbers() {
-        return phoneNumbers;
+        return Arrays.copyOf(phoneNumbers, phoneNumbers.length);
     }
 
     /**

--- a/dataproviders/src/test/java/com/paypal/selion/platform/dataprovider/pojos/yaml/USER.java
+++ b/dataproviders/src/test/java/com/paypal/selion/platform/dataprovider/pojos/yaml/USER.java
@@ -15,6 +15,8 @@
 
 package com.paypal.selion.platform.dataprovider.pojos.yaml;
 
+import java.util.Arrays;
+
 public class USER {
 
     /*

--- a/server/src/main/java/com/paypal/selion/grid/AbstractBaseLauncher.java
+++ b/server/src/main/java/com/paypal/selion/grid/AbstractBaseLauncher.java
@@ -15,15 +15,20 @@
 
 package com.paypal.selion.grid;
 
-import static com.paypal.selion.pojos.SeLionGridConstants.*;
-
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
-import com.google.gson.JsonParser;
-import com.paypal.selion.grid.LauncherOptions.LauncherOptionsImpl;
-import com.paypal.selion.grid.RunnableLauncher.InstanceType;
-import com.paypal.selion.logging.SeLionGridLogger;
-import com.paypal.selion.pojos.SeLionGridConstants;
+import static com.paypal.selion.pojos.SeLionGridConstants.HUB_CONFIG_ARG;
+import static com.paypal.selion.pojos.SeLionGridConstants.HUB_CONFIG_FILE;
+import static com.paypal.selion.pojos.SeLionGridConstants.HUB_CONFIG_FILE_RESOURCE;
+import static com.paypal.selion.pojos.SeLionGridConstants.HUB_SAUCE_CONFIG_FILE;
+import static com.paypal.selion.pojos.SeLionGridConstants.HUB_SAUCE_CONFIG_FILE_RESOURCE;
+import static com.paypal.selion.pojos.SeLionGridConstants.NODE_CONFIG_ARG;
+import static com.paypal.selion.pojos.SeLionGridConstants.NODE_CONFIG_FILE;
+import static com.paypal.selion.pojos.SeLionGridConstants.NODE_CONFIG_FILE_RESOURCE;
+import static com.paypal.selion.pojos.SeLionGridConstants.ROLE_ARG;
+import static com.paypal.selion.pojos.SeLionGridConstants.SAUCE_CONFIG_FILE;
+import static com.paypal.selion.pojos.SeLionGridConstants.SAUCE_CONFIG_FILE_RESOURCE;
+import static com.paypal.selion.pojos.SeLionGridConstants.SELION_CONFIG_ARG;
+import static com.paypal.selion.pojos.SeLionGridConstants.SELION_CONFIG_FILE;
+import static com.paypal.selion.pojos.SeLionGridConstants.TYPE_ARG;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -39,6 +44,12 @@ import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonParser;
+import com.paypal.selion.grid.LauncherOptions.LauncherOptionsImpl;
+import com.paypal.selion.logging.SeLionGridLogger;
 
 /**
  * An abstract base {@link RunnableLauncher} for SeLion Grid components
@@ -333,13 +344,13 @@ abstract class AbstractBaseLauncher implements RunnableLauncher {
         InstanceType type = getType();
         
         if (type.equals(InstanceType.SELENIUM_NODE)) {
-            result = SeLionGridConstants.NODE_CONFIG_FILE;
+            result = NODE_CONFIG_FILE;
             if (commands.contains("-nodeConfig")) {
                 result = commands.get(commands.indexOf("-nodeConfig" + 1));
             }
         }
         if (type.equals(InstanceType.SELENIUM_HUB)) {
-            result = SeLionGridConstants.HUB_CONFIG_FILE;
+            result = HUB_CONFIG_FILE;
             if (commands.contains("-hubConfig")) {
                 result = commands.get(commands.indexOf("-hubConfig" + 1));
             }

--- a/server/src/main/java/com/paypal/selion/grid/FileExtractor.java
+++ b/server/src/main/java/com/paypal/selion/grid/FileExtractor.java
@@ -94,8 +94,9 @@ final class FileExtractor {
             outputArchiveName = archiveFile.substring(0, archiveFile.lastIndexOf('.'));
             LOGGER.fine("Output archive name: " + outputArchiveName);
         }
-        // TODO: For any other compress format a simple else-if part with proper assignments will suffice
 
+        // TODO: For any other compress format a simple else-if part with proper assignments will suffice
+        String tempArchiveFile = archiveFile;
         if (isCompressedArchive) {
             LOGGER.fine("Found a compressed archive");
             CompressorInputStream is;
@@ -107,7 +108,7 @@ final class FileExtractor {
                 is.close();
                 decompressStream.close();
                 // The archive is de-compressed. Replacing the compressed file name to the archive name
-                archiveFile = outputArchiveName;
+                tempArchiveFile = outputArchiveName;
                 // Add the file name to the list
                 files.add(outputArchiveName);
             } catch (CompressorException | IOException e) {
@@ -116,13 +117,13 @@ final class FileExtractor {
         }
 
         archiveStreamType = ArchiveStreamFactory.ZIP;
-        if (archiveFile.endsWith(".tar")) {
+        if (tempArchiveFile.endsWith(".tar")) {
             archiveStreamType = ArchiveStreamFactory.TAR;
         }
         // TODO: For any new archive formats a simple else-if will suffice
 
         OutputStream outputFileStream = null;
-        LOGGER.fine("Getting file list for archive " + archiveFile);
+        LOGGER.fine("Getting file list for archive " + tempArchiveFile);
 
         List<String> executableNameList = FileExtractor.getExecutableNames();
         LOGGER.fine("Executable list: " + executableNameList.toString());
@@ -131,7 +132,7 @@ final class FileExtractor {
 
         try {
             archiveStream = new ArchiveStreamFactory().createArchiveInputStream(archiveStreamType,
-                    new FileInputStream(archiveFile));
+                    new FileInputStream(tempArchiveFile));
             ArchiveEntry entry;
             while ((entry = archiveStream.getNextEntry()) != null) {
                 String fileNameInEntry = getFileNameFromPath(entry.getName());

--- a/server/src/main/java/com/paypal/selion/grid/JarSpawner.java
+++ b/server/src/main/java/com/paypal/selion/grid/JarSpawner.java
@@ -41,6 +41,7 @@ public final class JarSpawner extends AbstractBaseProcessLauncher {
     }
 
     public JarSpawner(String[] args, ProcessLauncherOptions options) {
+        super();
         init(args, options);
     }
 

--- a/server/src/main/java/com/paypal/selion/grid/MobileProcessLauncher.java
+++ b/server/src/main/java/com/paypal/selion/grid/MobileProcessLauncher.java
@@ -60,6 +60,7 @@ class MobileProcessLauncher extends AbstractBaseProcessLauncher {
     }
 
     public MobileProcessLauncher(String[] args, ProcessLauncherOptions options) {
+        super();
         init(args, options);
     }
     

--- a/server/src/main/java/com/paypal/selion/grid/ProcessLauncherOptions.java
+++ b/server/src/main/java/com/paypal/selion/grid/ProcessLauncherOptions.java
@@ -15,9 +15,6 @@
 
 package com.paypal.selion.grid;
 
-import com.paypal.selion.SeLionConstants;
-import com.paypal.selion.pojos.SeLionGridConstants;
-
 /**
  * {@link LauncherOptions} which apply to {@link RunnableLauncher}s which spawn a new process
  */

--- a/server/src/main/java/com/paypal/selion/grid/ThreadedLauncher.java
+++ b/server/src/main/java/com/paypal/selion/grid/ThreadedLauncher.java
@@ -74,6 +74,7 @@ public final class ThreadedLauncher extends AbstractBaseLauncher {
      *            The list of binaries to download. These names MUST match the names from the download.json file
      */
     public ThreadedLauncher(String[] args, LauncherOptions launcherOptions, List<String> downloadList) {
+        super();
         setLauncherOptions(launcherOptions);
 
         InstallHelper.firstTimeSetup();

--- a/server/src/main/java/com/paypal/selion/grid/matchers/MobileCapabilityMatcher.java
+++ b/server/src/main/java/com/paypal/selion/grid/matchers/MobileCapabilityMatcher.java
@@ -86,10 +86,7 @@ public class MobileCapabilityMatcher extends DefaultCapabilityMatcher {
         if (StringUtils.isBlank(nodeValue)) {
             return false;
         }
-        if (!nodeValue.equalsIgnoreCase(mobileNodeType)) {
-            return false;
-        }
-        return true;
+        return nodeValue.equalsIgnoreCase(mobileNodeType);
     }
 
     /**

--- a/server/src/main/java/com/paypal/selion/grid/servlets/TransferServlet.java
+++ b/server/src/main/java/com/paypal/selion/grid/servlets/TransferServlet.java
@@ -52,7 +52,7 @@ public class TransferServlet extends HttpServlet {
     private static final SeLionGridLogger LOGGER = SeLionGridLogger.getLogger(TransferServlet.class);
 
     public void doPost(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse)
-            throws ServletException, java.io.IOException {
+            throws ServletException, IOException {
         LOGGER.entering((Object)new Object[] { httpServletRequest, httpServletResponse });
         try {
             TransferContext transferContext = new TransferContext(httpServletRequest, httpServletResponse);
@@ -73,7 +73,7 @@ public class TransferServlet extends HttpServlet {
     }
 
     public void doGet(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse)
-            throws ServletException, java.io.IOException {
+            throws ServletException, IOException {
         LOGGER.entering((Object)new Object[] { httpServletRequest, httpServletResponse });
         try {
             TransferContext transferContext = new TransferContext(httpServletRequest, httpServletResponse);

--- a/server/src/main/java/com/paypal/selion/grid/servlets/transfer/DefaultManagedArtifact.java
+++ b/server/src/main/java/com/paypal/selion/grid/servlets/transfer/DefaultManagedArtifact.java
@@ -22,6 +22,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.attribute.FileTime;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.logging.Level;
 
@@ -177,7 +178,7 @@ public class DefaultManagedArtifact implements ManagedArtifact {
         if (contents == null) {
             readContents();
         }
-        return contents;
+        return Arrays.copyOf(contents, contents.length);
     }
 
     public boolean matchesPathInfo(String pathInfo) {
@@ -219,10 +220,7 @@ public class DefaultManagedArtifact implements ManagedArtifact {
         if (!getSubFolderName().equals(otherManagedArtifact.getSubFolderName())) {
             return false;
         }
-        if (!getUIDFolderName().equals(otherManagedArtifact.getUIDFolderName())) {
-            return false;
-        }
-        return true;
+        return getUIDFolderName().equals(otherManagedArtifact.getUIDFolderName());
     }
 
     @Override

--- a/server/src/main/java/com/paypal/selion/grid/servlets/transfer/UploadedArtifact.java
+++ b/server/src/main/java/com/paypal/selion/grid/servlets/transfer/UploadedArtifact.java
@@ -15,6 +15,7 @@
 
 package com.paypal.selion.grid.servlets.transfer;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -50,7 +51,7 @@ public class UploadedArtifact {
      * @return the artifactContents
      */
     public byte[] getArtifactContents() {
-        return artifactContents;
+        return Arrays.copyOf(artifactContents, artifactContents.length);
     }
 
     /**

--- a/server/src/main/java/com/paypal/selion/proxy/SeLionRemoteProxy.java
+++ b/server/src/main/java/com/paypal/selion/proxy/SeLionRemoteProxy.java
@@ -381,6 +381,7 @@ public class SeLionRemoteProxy extends DefaultRemoteProxy {
         private final String nodeId;
 
         NodeRecycleThread(String nodeId) {
+            super();
             running = false;
             this.nodeId = nodeId;
         }

--- a/server/src/main/java/com/paypal/selion/utils/ConfigParser.java
+++ b/server/src/main/java/com/paypal/selion/utils/ConfigParser.java
@@ -38,20 +38,16 @@ import com.paypal.selion.pojos.SeLionGridConstants;
  *
  */
 public final class ConfigParser {
-    private static ConfigParser parser;
+    private static final SeLionGridLogger LOGGER = SeLionGridLogger.getLogger(ConfigParser.class);
+    private static ConfigParser parser = new ConfigParser();
     private JsonObject configuration;
     private static String configFile;
-    private static final SeLionGridLogger LOGGER = SeLionGridLogger.getLogger(ConfigParser.class);
 
     /**
      * @return A {@link ConfigParser} object that can be used to retrieve values from the Configuration object as
      *         represented by the JSON file passed via the JVM argument <b>SeLionConfig</b>
      */
     public static ConfigParser parse() {
-        LOGGER.entering();
-        if (parser == null) {
-            parser = new ConfigParser();
-        }
         LOGGER.exiting(parser.toString());
         return parser;
     }

--- a/server/src/main/java/com/paypal/selion/utils/FileBackedStringBuffer.java
+++ b/server/src/main/java/com/paypal/selion/utils/FileBackedStringBuffer.java
@@ -86,7 +86,7 @@ public class FileBackedStringBuffer {
                 copy(new FileReader(file), bw);
             }
         } catch (IOException ex) {
-            ex.printStackTrace();
+            LOGGER.log(Level.WARNING, ex.getMessage(), ex);
         }
     }
 

--- a/server/src/main/java/com/paypal/selion/utils/process/ProcessHandlerException.java
+++ b/server/src/main/java/com/paypal/selion/utils/process/ProcessHandlerException.java
@@ -27,6 +27,7 @@ public class ProcessHandlerException extends Exception {
     private static final long serialVersionUID = 5445790498525782457L;
 
     public ProcessHandlerException() {
+        super();
     }
 
     public ProcessHandlerException(String message) {

--- a/server/src/main/java/com/paypal/selion/utils/process/StreamGobbler.java
+++ b/server/src/main/java/com/paypal/selion/utils/process/StreamGobbler.java
@@ -33,6 +33,7 @@ public class StreamGobbler extends Thread {
     private final List<String> contents = new ArrayList<>();
 
     public StreamGobbler(InputStream stream) {
+        super();
         this.stream = new InputStreamReader(stream);
     }
 

--- a/server/src/main/java/com/paypal/selion/utils/process/UnixProcessHandler.java
+++ b/server/src/main/java/com/paypal/selion/utils/process/UnixProcessHandler.java
@@ -30,6 +30,7 @@ import com.paypal.selion.pojos.ProcessNames;
  */
 public class UnixProcessHandler extends AbstractProcessHandler implements ProcessHandler {
     public UnixProcessHandler() {
+        super();
         LOGGER.info("You have chosen to use a Unix Process Handler.");
     }
 

--- a/server/src/main/java/com/paypal/selion/utils/process/WindowsProcessHandler.java
+++ b/server/src/main/java/com/paypal/selion/utils/process/WindowsProcessHandler.java
@@ -32,6 +32,7 @@ public class WindowsProcessHandler extends AbstractProcessHandler implements Pro
     private static final String DELIMITER = ",";
 
     public WindowsProcessHandler() {
+        super();
         LOGGER.info("You have chosen to use a Windows Process Handler.");
     }
 

--- a/server/src/test/java/com/paypal/selion/grid/ArtifactDetailsTest.java
+++ b/server/src/test/java/com/paypal/selion/grid/ArtifactDetailsTest.java
@@ -34,7 +34,7 @@ public class ArtifactDetailsTest {
         File fileToTest = new File("src/test/resources/config/Dummydownload.json");
         List<URLChecksumEntity> parsedDetails = ArtifactDetails.getArtifactDetailsForCurrentPlatformByRole(fileToTest,
                 InstanceType.SELENIUM_NODE);
-        assertTrue(parsedDetails.size() == 2);
+        assertEquals(parsedDetails.size(), 2);
         URLChecksumEntity entity = parsedDetails.get(0);
         // Asserting for details read using any key
         assertEquals(entity.getUrl().getValue(), "seleniumURL");
@@ -53,7 +53,7 @@ public class ArtifactDetailsTest {
         File fileToTest = new File("src/test/resources/config/Dummydownload.json");
         List<URLChecksumEntity> parsedDetails = ArtifactDetails.getArtifactDetailsForCurrentPlatformByNames(fileToTest,
                 downloads);
-        assertTrue(parsedDetails.size() == 1);
+        assertEquals(parsedDetails.size(), 1);
         URLChecksumEntity entity = parsedDetails.get(0);
         // Asserting for details read using any key
         assertEquals(entity.getUrl().getValue(), "seleniumURL");

--- a/server/src/test/java/com/paypal/selion/grid/FileExtractorTest.java
+++ b/server/src/test/java/com/paypal/selion/grid/FileExtractorTest.java
@@ -84,7 +84,7 @@ public class FileExtractorTest extends PowerMockTestCase {
     public void testExtractingZip() {
         List<String> files = FileExtractor.extractArchive(DUMMY_ZIP_ARCHIVE_FILE_PATH);
         assertTrue(extractedFile.exists());
-        assertTrue(files.size() == 1);
+        assertEquals(files.size(), 1);
     }
 
     @Test
@@ -97,7 +97,7 @@ public class FileExtractorTest extends PowerMockTestCase {
                         .getAbsolutePath());
 
         assertTrue(tarFile.exists());
-        assertTrue(files.size() == 2);
+        assertEquals(files.size(), 2);
     }
 
     @AfterMethod(alwaysRun = true)

--- a/server/src/test/java/com/paypal/selion/grid/matchers/MobileCapabilityMatcherTest.java
+++ b/server/src/test/java/com/paypal/selion/grid/matchers/MobileCapabilityMatcherTest.java
@@ -15,7 +15,8 @@
 
 package com.paypal.selion.grid.matchers;
 
-import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 import io.selendroid.common.SelendroidCapabilities;
 
 import java.util.HashMap;
@@ -24,8 +25,6 @@ import java.util.Map;
 import org.openqa.selenium.remote.CapabilityType;
 import org.testng.annotations.Test;
 import org.uiautomation.ios.IOSCapabilities;
-
-import com.paypal.selion.grid.matchers.MobileCapabilityMatcher;
 
 public class MobileCapabilityMatcherTest {
 
@@ -44,13 +43,13 @@ public class MobileCapabilityMatcherTest {
         requestedCapability.put("platformName", "Android");
         requestedCapability.put("platformVersion", "4.4.2");
         requestedCapability.put("deviceName", "Android Emulator");
-        assertEquals(matcher.matches(nodeCapability, requestedCapability), true);
+        assertTrue(matcher.matches(nodeCapability, requestedCapability));
 
         //Success scenario2
         requestedCapability.clear();
         requestedCapability.put("mobileNodeType", "appium");
         requestedCapability.put("platformName", "Android");
-        assertEquals(matcher.matches(nodeCapability, requestedCapability), true);
+        assertTrue(matcher.matches(nodeCapability, requestedCapability));
 
         //Failure scenario
         requestedCapability.clear();
@@ -58,7 +57,7 @@ public class MobileCapabilityMatcherTest {
         requestedCapability.put("platformName", "Android");
         requestedCapability.put("platformVersion", "4.2.2");
         requestedCapability.put("deviceName", "Android Emulator");
-        assertEquals(matcher.matches(nodeCapability, requestedCapability), false);
+        assertFalse(matcher.matches(nodeCapability, requestedCapability));
     }
 
     @Test
@@ -75,13 +74,13 @@ public class MobileCapabilityMatcherTest {
         requestedCapability.put(CapabilityType.BROWSER_NAME, "selendroid");
         requestedCapability.put(SelendroidCapabilities.AUT, "appname");
         requestedCapability.put(SelendroidCapabilities.LOCALE, "en_us");
-        assertEquals(matcher.matches(nodeCapability, requestedCapability), true);
+        assertTrue(matcher.matches(nodeCapability, requestedCapability));
 
         //Failure scenario
         requestedCapability.clear();
         requestedCapability.put("mobileNodeType", "selendroid");
         requestedCapability.put(CapabilityType.BROWSER_NAME, "firefox");
-        assertEquals(matcher.matches(nodeCapability, requestedCapability), false);
+        assertFalse(matcher.matches(nodeCapability, requestedCapability));
     }
 
     @Test
@@ -95,7 +94,7 @@ public class MobileCapabilityMatcherTest {
         requestedCapability.put(IOSCapabilities.LANGUAGE, "english");
         requestedCapability.put(IOSCapabilities.LOCALE, "en_us");
         requestedCapability.put(IOSCapabilities.BUNDLE_NAME, "appname");
-        assertEquals(matcher.matches(new HashMap<String, Object>(), requestedCapability), false);
+        assertFalse(matcher.matches(new HashMap<String, Object>(), requestedCapability));
     }
 
     @Test
@@ -109,7 +108,7 @@ public class MobileCapabilityMatcherTest {
         Map<String, Object> requestedCapability = new HashMap<String, Object>();
         requestedCapability.put(CapabilityType.BROWSER_NAME, "chrome");
 
-        assertEquals(matcher.matches(nodeCapability, requestedCapability), true);
+        assertTrue(matcher.matches(nodeCapability, requestedCapability));
     }
 
     @Test
@@ -124,6 +123,6 @@ public class MobileCapabilityMatcherTest {
         requestedCapability.put("mobileNodeType", "");
         requestedCapability.put(CapabilityType.BROWSER_NAME, "ff");
 
-        assertEquals(matcher.matches(nodeCapability, requestedCapability), true);
+        assertTrue(matcher.matches(nodeCapability, requestedCapability));
     }
 }


### PR DESCRIPTION
- Enforces calling super inside constructor
- Prohibitis reassigning values to parameters
- Prohibits if-else when returning boolean
- Prohibitis return of internal arrays
- Enforces never changed fields to final
- Prohibits unnecessary comparisions in boolean expressions
- Enforces literals first in comparisons
- Prohibitis non thread safe singletons
- Import statements allow the use of non-fully qualified names
- Use assertSame/assetNotSame in assertions when testing object referrences equality
- Use asserrTrue/assertFalse to assert boolean values
- Avoid unused import statements
