### PR TITLE
Fix #220 - appName and appPath processing bug

### DIFF
--- a/client/src/main/java/com/paypal/selion/annotations/MobileTest.java
+++ b/client/src/main/java/com/paypal/selion/annotations/MobileTest.java
@@ -52,35 +52,35 @@ public @interface MobileTest {
     String appName() default "";
 
     /**
-     * Establish the type of device to be used(android, iphone, etc). Default's to <code>iphone</code> Platform version
-     * can be specified as part of the device as:
+     * Establish the type of device to be used (android, iphone, etc). No default. Platform version can be specified as
+     * part of the device as:
      * 
      * <pre>
      * device = &quot;iphone:7.1&quot;
      * </pre>
      */
-    String device() default "iphone";
+    String device() default "";
 
     /**
-     * Establish the application's language that is to be used. Default's to <code>English</code> specified as
-     * <code>en</code>
+     * Establish the application's language that is to be used. For example; <code>en</code> for English. Defaults to
+     * the language chosen by Selendroid / ios-driver / Appium
      */
-    String language() default "en";
+    String language() default "";
 
     /**
-     * Establish the application's locale that is to be used. Default's to <code>English</code> specified as
-     * <code>en_US</code>
+     * Establish the application's locale that is to be used. For example; <code>en_US</code> for US English. Defaults
+     * to the locale chosen by Selendroid / ios-driver / Appium
      */
-    String locale() default "en_US";
+    String locale() default "";
 
     /**
-     * Device Serial to be used. Defaults to device/emulator chosen by Selendroid / iosDriver
+     * Device Serial to be used. Defaults to the device/emulator chosen by Selendroid / ios-driver / Appium
      */
     String deviceSerial() default "";
 
     /**
-     * Establish the type of device to be used (Nexus5, Iphone5s, etc). Defaults to device/emulator chosen by Selendroid
-     * / iosDriver /Appium
+     * Establish the type of device to be used (Nexus5, Iphone5s, etc). Defaults to the device/emulator chosen by
+     * Selendroid / ios-driver / Appium
      */
     String deviceType() default "";
 
@@ -102,7 +102,7 @@ public @interface MobileTest {
      * This parameter represents the fully qualified path of the app that is to be spawned. For app exist in the local
      * disk this should be an absolute path, for app exist in the remote location it should be http URL and for app
      * exist in sauce cloud it can be sauce storage "sauce-storage:testApp.apk". This is mandatory for installable apps
-     * running on appium. appPath cannot be used along with the appName.
+     * running on Appium. <code>appPath</code> cannot be used along with the <code>appName</code>.
      * 
      * <pre>
      *  for app in local disk it can be like appPath = C:\\test\\testApp.apk;
@@ -111,7 +111,7 @@ public @interface MobileTest {
      * </pre>
      */
     String appPath() default "";
-    
+
     /**
      * This parameter specifies to execute mobile test cases using respective mobile driver.
      */

--- a/client/src/main/java/com/paypal/selion/internal/platform/grid/AbstractTestSession.java
+++ b/client/src/main/java/com/paypal/selion/internal/platform/grid/AbstractTestSession.java
@@ -223,7 +223,7 @@ public abstract class AbstractTestSession {
     /**
      * A Method to start a new session.
      */
-    public abstract void startSesion();
+    public abstract void startSession();
 
     /**
      * A initializer that initializes the sub-class of {@link AbstractTestSession} based on the annotation.

--- a/client/src/main/java/com/paypal/selion/internal/platform/grid/BasicTestSession.java
+++ b/client/src/main/java/com/paypal/selion/internal/platform/grid/BasicTestSession.java
@@ -28,7 +28,7 @@ public class BasicTestSession extends AbstractTestSession {
     private static final SimpleLogger logger = SeLionLogger.getLogger();
 
     @Override
-    public void startSesion() {
+    public void startSession() {
         logger.entering();
         setStarted(true);
         logger.exiting();

--- a/client/src/main/java/com/paypal/selion/internal/platform/grid/MobileTestSession.java
+++ b/client/src/main/java/com/paypal/selion/internal/platform/grid/MobileTestSession.java
@@ -77,7 +77,7 @@ public class MobileTestSession extends AbstractTestSession {
         return appVersion;
     }
 
-    public String getdeviceSerial() {
+    public String getDeviceSerial() {
         return deviceSerial;
     }
 
@@ -110,7 +110,7 @@ public class MobileTestSession extends AbstractTestSession {
     }
 
     @Override
-    public void startSesion() {
+    public void startSession() {
         logger.entering();
         Grid.getThreadLocalWebDriver().set(MobileDriverFactory.createInstance());
         setStarted(true);
@@ -146,15 +146,11 @@ public class MobileTestSession extends AbstractTestSession {
         if (StringUtils.isNotBlank(getLocalConfigProperty(ConfigProperty.MOBILE_APP_LANGUAGE))) {
             appLanguage = getLocalConfigProperty(ConfigProperty.MOBILE_APP_LANGUAGE);
         }
+
         // Override values when supplied via the annotation
         if (deviceTestAnnotation != null) {
             if (StringUtils.isNotBlank(deviceTestAnnotation.appName())) {
                 this.appName = deviceTestAnnotation.appName();
-                String[] appNames = StringUtils.split(this.appName, ":");
-                if (StringUtils.contains(this.appName, ":")) {
-                    appVersion = appNames[1];
-                    appName = appNames[0];
-                }
             }
 
             if (StringUtils.isNotBlank(deviceTestAnnotation.language())) {
@@ -179,18 +175,6 @@ public class MobileTestSession extends AbstractTestSession {
             }
             if (StringUtils.isNotBlank(deviceTestAnnotation.appPath())) {
                 this.appPath = deviceTestAnnotation.appPath();
-
-                if (this.appPath.startsWith(SELION_HUB_STORAGE)) {
-                    // parse and construct the absolute url for selion hub storage
-                    this.appPath = getSelionHubStorageUrl(this.appPath);
-                } else if (!this.appPath.startsWith(SAUCE_URL) && !StringUtils.startsWithIgnoreCase(appPath, "http")) {
-
-                    // construct the absolute url for apps exist in resource folder.
-                    Path p = Paths.get(appPath);
-                    if (!p.isAbsolute()) {
-                        this.appPath = String.format("%s/%s", System.getProperty("user.dir"), appPath);
-                    }
-                }
             }
             if (StringUtils.isNotBlank(deviceTestAnnotation.mobileNodeType())) {
                 mobileNode = deviceTestAnnotation.mobileNodeType();
@@ -214,6 +198,25 @@ public class MobileTestSession extends AbstractTestSession {
                 "The device should either be provided as 'iphone', 'ipad', 'iphone:7.1', 'android',"
                         + " 'android:17', 'android:18', etc.");
 
+        // appName can be passed via the annotation or as a config var. It may contain precision info.
+        if (StringUtils.contains(this.appName, ":")) {
+            String[] appNames = StringUtils.split(this.appName, ":");
+            appVersion = appNames[1];
+            appName = appNames[0];
+        }
+
+        // appPath can be passed via the annotation or as a config var. It may need formatting.
+        if (this.appPath.startsWith(SELION_HUB_STORAGE)) {
+            // parse and construct the absolute url for selion hub storage
+            this.appPath = getSelionHubStorageUrl(this.appPath);
+        } else if (!this.appPath.startsWith(SAUCE_URL) && !StringUtils.startsWithIgnoreCase(appPath, "http")) {
+            // construct the absolute url for apps exist in resource folder.
+            Path p = Paths.get(appPath);
+            if (!p.isAbsolute()) {
+                this.appPath = String.format("%s/%s", System.getProperty("user.dir"), appPath);
+            }
+        }
+
         this.platform = WebDriverPlatform.ANDROID;
         if ("iphone".equalsIgnoreCase(getDevice()) || "ipad".equalsIgnoreCase(getDevice())) {
             this.platform = WebDriverPlatform.IOS;
@@ -222,10 +225,10 @@ public class MobileTestSession extends AbstractTestSession {
         logger.exiting();
     }
 
-    private String getSelionHubStorageUrl(String selionHubappPath) {
+    private String getSelionHubStorageUrl(String selionHubAppPath) {
         String COLON = ":";
         String SLASH = "/";
-        String appPathTokens[] = StringUtils.split(selionHubappPath, ":");
+        String appPathTokens[] = StringUtils.split(selionHubAppPath, ":");
         String hostName = Config.getConfigProperty(ConfigProperty.SELENIUM_HOST);
         int port = Integer.parseInt(Config.getConfigProperty(ConfigProperty.SELENIUM_PORT));
         StringBuffer url = new StringBuffer("http://");

--- a/client/src/main/java/com/paypal/selion/internal/platform/grid/WebTestSession.java
+++ b/client/src/main/java/com/paypal/selion/internal/platform/grid/WebTestSession.java
@@ -157,7 +157,7 @@ public class WebTestSession extends AbstractTestSession {
     }
 
     @Override
-    public void startSesion() {
+    public void startSession() {
         createSession();
         setStarted(true);
     }

--- a/client/src/main/java/com/paypal/selion/internal/platform/grid/browsercapabilities/SelendroidCapabilitiesBuilder.java
+++ b/client/src/main/java/com/paypal/selion/internal/platform/grid/browsercapabilities/SelendroidCapabilitiesBuilder.java
@@ -56,8 +56,8 @@ class SelendroidCapabilitiesBuilder extends DefaultCapabilitiesBuilder {
         if (StringUtils.isNotBlank(mobileSession.getPlatformVersion())) {
             tempCapabilities.setCapability(SelendroidCapabilities.PLATFORM_VERSION, mobileSession.getPlatformVersion());
         }
-        if (StringUtils.isNotBlank(mobileSession.getdeviceSerial())) {
-            tempCapabilities.setCapability(SelendroidCapabilities.SERIAL, mobileSession.getdeviceSerial());
+        if (StringUtils.isNotBlank(mobileSession.getDeviceSerial())) {
+            tempCapabilities.setCapability(SelendroidCapabilities.SERIAL, mobileSession.getDeviceSerial());
         }
         return tempCapabilities;
     }

--- a/client/src/main/java/com/paypal/selion/platform/grid/Grid.java
+++ b/client/src/main/java/com/paypal/selion/platform/grid/Grid.java
@@ -104,7 +104,7 @@ public final class Grid {
 
         AbstractTestSession testSession = getTestSession();
         if (!testSession.isStarted()) {
-            testSession.startSesion();
+            testSession.startSession();
         }
         RemoteWebDriver rwd = threadLocalWebDriver.get();
         if (rwd == null) {


### PR DESCRIPTION
Processing of appName and appPath in MobileTestSession was not
happening when values were passed as config properties
