### PR TITLE
Fixing a missed copyright update.

### DIFF
--- a/client/src/main/java/com/paypal/selion/testcomponents/BasicPageImpl.java
+++ b/client/src/main/java/com/paypal/selion/testcomponents/BasicPageImpl.java
@@ -1,5 +1,5 @@
 /*-------------------------------------------------------------------------------------------------------------------*\
-|  Copyright (C) 2014-15 eBay Software Foundation                                                                     |
+|  Copyright (C) 2014-15 PayPal                                                                                       |
 |                                                                                                                     |
 |  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
 |  with the License.                                                                                                  |


### PR DESCRIPTION
client/src/main/java/com/paypal/selion/testcomponents/BasicPageImpl.java looks like it didn't get updated copyright information after the split.

Fixes #224 
