### PR TITLE
SelionSauceProxy improvements

### DIFF
--- a/server/src/main/java/com/paypal/selion/grid/AbstractBaseLauncher.java
+++ b/server/src/main/java/com/paypal/selion/grid/AbstractBaseLauncher.java
@@ -217,6 +217,7 @@ abstract class AbstractBaseLauncher implements RunnableLauncher {
             if (commands.contains(TYPE_ARG) && commands.contains(InstanceType.SELION_SAUCE_HUB.getFriendlyName())) {
                 hubConfig = HUB_SAUCE_CONFIG_FILE;
                 InstallHelper.copyFileFromResources(HUB_SAUCE_CONFIG_FILE_RESOURCE, HUB_SAUCE_CONFIG_FILE);
+                InstallHelper.copyFileFromResources(NODE_SAUCE_CONFIG_FILE_RESOURCE, NODE_SAUCE_CONFIG_FILE);
                 InstallHelper.copyFileFromResources(SAUCE_CONFIG_FILE_RESOURCE, SAUCE_CONFIG_FILE);
             } else {
                 InstallHelper.copyFileFromResources(HUB_CONFIG_FILE_RESOURCE, HUB_CONFIG_FILE);

--- a/server/src/main/java/com/paypal/selion/grid/servlets/SauceServlet.java
+++ b/server/src/main/java/com/paypal/selion/grid/servlets/SauceServlet.java
@@ -15,6 +15,7 @@
 
 package com.paypal.selion.grid.servlets;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 
@@ -22,6 +23,8 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.paypal.selion.pojos.SeLionGridConstants;
+import org.apache.commons.io.FileUtils;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
@@ -32,7 +35,6 @@ import org.openqa.grid.internal.Registry;
 import org.openqa.grid.web.servlet.RegistryBasedServlet;
 import org.openqa.selenium.remote.internal.HttpClientFactory;
 
-import com.paypal.selion.proxy.SeLionSauceProxy;
 import com.paypal.selion.utils.ServletHelper;
 
 /**
@@ -82,22 +84,7 @@ public class SauceServlet extends RegistryBasedServlet {
 
             BasicHttpEntityEnclosingRequest r = new BasicHttpEntityEnclosingRequest("POST",
                     registration.toExternalForm());
-            // TODO: Maybe we should consider putting in this registration request in a JSON file
-            // for ease of editing it, in-case something changes.
-            String json = "{\"class\":\"org.openqa.grid.common.RegistrationRequest\","
-                    + "\"capabilities\":["
-                    + "{\"platform\":\"ANY\",\"browserName\":\"firefox\",\"maxInstances\":20},"
-                    + "{\"platform\":\"ANY\",\"browserName\":\"internet explorer\",\"maxInstances\":20}"
-                    + "],"
-                    // TODO: We are assuming that port 5555 would always be available for us to use. But what
-                    // if that port is already hard wired to some other application thereby causing the node to never
-                    // be able to come up at all ? Perhaps parameterize this too ?
-                    + "\"configuration\":{\"port\":5555,\"register\":true," + "\"cleanUpCycle\":30000,"
-                    + "\"timeout\":120000," + "\"proxy\":\"" + SeLionSauceProxy.class.getCanonicalName() + "\","
-                    + "\"maxSession\":100,"
-                    + "\"hubHost\":\"localhost\",\"role\":\"wd\",\"registerCycle\":5000,\"hubPort\":" + port + ","
-                    + "\"url\":\"http://localhost:" + port + "\",\"remoteHost\":\"http://localhost:" + port + "\"}"
-                    + "}";
+            String json = FileUtils.readFileToString(new File(SeLionGridConstants.NODE_SAUCE_CONFIG_FILE));
             r.setEntity(new StringEntity(json));
             HttpHost host = new HttpHost(registration.getHost(), registration.getPort());
             HttpClientFactory httpClientFactory = new HttpClientFactory();
@@ -106,7 +93,7 @@ public class SauceServlet extends RegistryBasedServlet {
             // TODO: Should we do something with the status code for e.g., check if it was "200". Maybe attempt a few
             // retries as well if the registration didnt go through ?
 
-            respMsg = "<p align='center'><b>Sauce node registration got failed. Please refer to the log file for failure details</b></p>";
+            respMsg = "<p align='center'><b>Sauce node registration failed. Please refer to the log file for failure details</b></p>";
 
             if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
                 respMsg = "<p align='center'><b>Sauce node registered successfully</b></p>";

--- a/server/src/main/java/com/paypal/selion/pojos/SeLionGridConstants.java
+++ b/server/src/main/java/com/paypal/selion/pojos/SeLionGridConstants.java
@@ -105,6 +105,11 @@ public class SeLionGridConstants {
     public static final String HUB_SAUCE_CONFIG_FILE_RESOURCE = "/" + CONFIG_DIR + "hubSauceConfig.json";
 
     /**
+     * Resource path to the default nodeSauceConfig.json file
+     */
+    public static final String NODE_SAUCE_CONFIG_FILE_RESOURCE = "/" + CONFIG_DIR + "nodeSauceConfig.json";
+
+    /**
      * Installed/Extracted path to the hubConfig.json file
      */
     public static final String HUB_CONFIG_FILE = FilenameUtils.separatorsToSystem(SELION_HOME_DIR + CONFIG_DIR
@@ -115,6 +120,12 @@ public class SeLionGridConstants {
      */
     public static final String HUB_SAUCE_CONFIG_FILE = FilenameUtils.separatorsToSystem(SELION_HOME_DIR + CONFIG_DIR
             + "hubSauceConfig.json");
+
+    /**
+     * Installed/Extracted path to the nodeSauceConfig.json file
+     */
+    public static final String NODE_SAUCE_CONFIG_FILE = FilenameUtils.separatorsToSystem(SELION_HOME_DIR + CONFIG_DIR
+            + "nodeSauceConfig.json");
 
     /**
      * Resource path to the default sauceConfig.json file

--- a/server/src/main/resources/config/nodeSauceConfig.json
+++ b/server/src/main/resources/config/nodeSauceConfig.json
@@ -1,0 +1,30 @@
+{
+    "class": "org.openqa.grid.common.RegistrationRequest",
+    "capabilities": [{
+        "platform": "ANY",
+        "browserName": "firefox",
+        "maxInstances": 20
+    }, {
+        "platform": "ANY",
+        "browserName": "chrome",
+        "maxInstances": 20
+    }, {
+        "platform": "ANY",
+        "browserName": "internet explorer",
+        "maxInstances": 20
+    }],
+    "configuration": {
+        "port": 5555,
+        "register": true,
+        "cleanUpCycle": 30000,
+        "timeout": 120000,
+        "proxy": "com.paypal.selion.proxy.SeLionSauceProxy",
+        "maxSession": 100,
+        "hubHost": "localhost",
+        "role": "wd",
+        "registerCycle": 5000,
+        "hubPort": 4444,
+        "url": "http://localhost:4444",
+        "remoteHost": "http://localhost:4444"
+    }
+}

--- a/server/src/test/java/com/paypal/selion/proxy/SeLionSauceProxyTest.java
+++ b/server/src/test/java/com/paypal/selion/proxy/SeLionSauceProxyTest.java
@@ -1,0 +1,64 @@
+package com.paypal.selion.proxy;
+
+import com.paypal.selion.SeLionConstants;
+import com.paypal.selion.pojos.SeLionGridConstants;
+import org.apache.commons.io.FileUtils;
+import org.openqa.grid.common.RegistrationRequest;
+import org.openqa.grid.internal.RemoteProxy;
+import org.openqa.grid.internal.utils.GridHubConfiguration;
+import org.openqa.grid.selenium.proxy.DefaultRemoteProxy;
+import org.openqa.grid.web.Hub;
+import org.openqa.selenium.remote.internal.HttpClientFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.InputStream;
+
+import static org.testng.Assert.assertTrue;
+
+public class SeLionSauceProxyTest {
+
+    private HttpClientFactory httpClientFactory;
+    private Hub hub;
+    private RegistrationRequest req;
+    private File tempFile;
+
+    @BeforeClass
+    public void setup() throws Exception {
+        httpClientFactory = new HttpClientFactory();
+        String[] args = new String[] {
+                "-role", "hub", "-type", "sauce",
+                "-host", "localhost",
+                "-servlets", "com.paypal.selion.grid.servlets.LoginServlet,com.paypal.selion.grid.servlets.SauceServlet",
+        };
+        GridHubConfiguration ghc = GridHubConfiguration.build(args);
+        hub = new Hub(ghc);
+    }
+
+    @Test()
+    public void testSauceProxyConfig() throws Exception {
+        InputStream stream = this.getClass().getResourceAsStream(SeLionGridConstants.NODE_SAUCE_CONFIG_FILE_RESOURCE);
+        tempFile = File.createTempFile("selion-test", null);
+        FileUtils.copyInputStreamToFile(stream, tempFile);
+        req = new RegistrationRequest();
+        req.loadFromJSON(tempFile.toString());
+        assertTrue(req.getCapabilities().size() > 0);
+    }
+
+    @Test(dependsOnMethods = "testSauceProxyConfig")
+    public void testSauceProxy() throws Exception {
+        RemoteProxy p = DefaultRemoteProxy.getNewInstance(req, hub.getRegistry());
+        assertTrue(p instanceof SeLionSauceProxy);
+        assertTrue(p.getStatus() != null);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown() throws Exception {
+        tempFile.delete();
+        hub.stop();
+        httpClientFactory.close();
+    }
+}

--- a/server/src/test/resources/Default-Suite.xml
+++ b/server/src/test/resources/Default-Suite.xml
@@ -10,6 +10,7 @@
         </groups>
         <packages>
             <package name="com.paypal.selion.grid.*" />
+            <package name="com.paypal.selion.proxy.*" />
         </packages>
     </test>
 </suite>


### PR DESCRIPTION
Improvement to SeLionSauceProxy when connecting to Sauce Labs REST.
Add a configurable timeout (default of 10 seconds) for URL connections to SauceLabs REST API.
Add a (configurable) retry on failures with SauceLabs REST API.
Refactor SeLion sauce node configuration into json file.
