### PR TITLE
Fix exception handling when SauceLabs goes down

### DIFF
--- a/server/src/main/java/com/paypal/selion/proxy/SeLionSauceProxy.java
+++ b/server/src/main/java/com/paypal/selion/proxy/SeLionSauceProxy.java
@@ -101,7 +101,7 @@ public class SeLionSauceProxy extends DefaultRemoteProxy {
             String result = getSauceLabsRestApi(SauceConfigReader.getInstance().getURL() + "/activity");
             JsonObject obj = new JsonParser().parse(result).getAsJsonObject();
             return obj.getAsJsonObject("totals").get("all").getAsInt();
-        } catch (JsonSyntaxException e) {
+        } catch (JsonSyntaxException | IllegalStateException e) {
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
         }
         return getMaxTestcase() + 1;
@@ -135,7 +135,7 @@ public class SeLionSauceProxy extends DefaultRemoteProxy {
                 String result = getSauceLabsRestApi(SauceConfigReader.getInstance().getURL() + "/limits");
                 JsonObject obj = new JsonParser().parse(result).getAsJsonObject();
                 maxTestCase = obj.get("concurrency").getAsInt();
-            } catch (JsonSyntaxException e) {
+            } catch (JsonSyntaxException | IllegalStateException e) {
                 LOGGER.log(Level.SEVERE, e.getMessage(), e);
             }
         }


### PR DESCRIPTION
Getting the number of Test cases running from sauceLabs fails
we return an empty string (after several retries to Sauce)
which causes an illegalStateException on parsing in
SeLionSauceProxy. Now log and continue.
