### PR TITLE
Add WerFault process on Windows

### DIFF
--- a/server/src/main/java/com/paypal/selion/pojos/ProcessNames.java
+++ b/server/src/main/java/com/paypal/selion/pojos/ProcessNames.java
@@ -24,7 +24,8 @@ public enum ProcessNames {
     CHROME("chrome.exe", "chrome"),
     CHROMEDRIVER("chromedriver.exe", "chromedriver"),
     IEDRIVER("iedriverserver.exe", "NOTAPPLICABLE"),
-    PHANTOMJS("phantomjs.exe", "phantomjs");
+    PHANTOMJS("phantomjs.exe", "phantomjs"),
+    WERFAULT("werfault.exe", "NOTAPPLICABLE");
 
     private ProcessNames(String windowsImageName, String unixImageName) {
         this.windowsImageName = windowsImageName;

--- a/server/src/main/java/com/paypal/selion/utils/process/WindowsProcessHandler.java
+++ b/server/src/main/java/com/paypal/selion/utils/process/WindowsProcessHandler.java
@@ -42,12 +42,13 @@ public class WindowsProcessHandler extends AbstractProcessHandler implements Pro
         int ourPid = getCurrentProcessID();
 
         // Find all processes names that are our direct children using our PID as the parent pid using wmic.
-        // As well as iexplore process that are orphaned.
+        // As well as any iexplore or werfault processes that are orphans.
         // We want to kill only the direct child processes we have started. ("More +2" drops the csv header from output)
-        // Note that we plan to kill all child process descendants in killProcess (with /T)
-        String cmd = String.format("wmic process where (parentprocessid=%s or name=\"%s\") " +
+        // Note that we plan to kill all candidate descendants in killProcess (with /T)
+        String cmd = String.format("wmic process where (parentprocessid=%s or name=\"%s\" or name=\"%s\") " +
                         "get name,processid /format:csv | more +2",
-                String.valueOf(ourPid), ProcessNames.INTERNET_EXPLORER.getWindowsImageName());
+                String.valueOf(ourPid), ProcessNames.INTERNET_EXPLORER.getWindowsImageName(), ProcessNames.WERFAULT
+                        .getWindowsImageName());
         try {
             List<ProcessInfo> processToBeKilled = getProcessInfo(new String[] { "cmd.exe", "/C", cmd }, DELIMITER,
                     OSPlatform.WINDOWS);


### PR DESCRIPTION
Add WerFault.exe (Windows Error Reporting) process to the list of process
we search for and kill on a node recycle.
