### PR TITLE
Add before and after screenshot events to the element event listener.

### DIFF
--- a/client/src/main/java/com/paypal/selion/platform/html/AbstractElement.java
+++ b/client/src/main/java/com/paypal/selion/platform/html/AbstractElement.java
@@ -387,6 +387,8 @@ public abstract class AbstractElement implements Clickable, Hoverable {
         logger.entering();
         processAlerts(Grid.getWebTestSession().getBrowser());
 
+        dispatcher.beforeScreenshot(this);
+        
         String title = "Default Title";
         try {
             title = Grid.driver().getTitle();
@@ -399,6 +401,9 @@ public abstract class AbstractElement implements Clickable, Hoverable {
         } else {
             SeLionReporter.log(title, false, logPages);
         }
+        
+        dispatcher.afterScreenshot(this);
+        
         logger.exiting();
     }
 

--- a/client/src/main/java/com/paypal/selion/platform/html/support/events/AbstractElementEventListener.java
+++ b/client/src/main/java/com/paypal/selion/platform/html/support/events/AbstractElementEventListener.java
@@ -30,6 +30,16 @@ public abstract class AbstractElementEventListener implements ElementEventListen
     public void afterClick(Clickable target, Object... expected) {
         //NOSONAR
     }
+    
+    @Override
+    public void beforeScreenshot(Clickable target) {
+        //NOSONAR
+    }
+
+    @Override
+    public void afterScreenshot(Clickable target) {
+        //NOSONAR
+    }
 
     @Override
     public void beforeType(Typeable target, String value) {
@@ -150,4 +160,6 @@ public abstract class AbstractElementEventListener implements ElementEventListen
     public void afterHover(Hoverable target, Object... expected) {
         //NOSONAR
     }
+    
+    
 }

--- a/client/src/main/java/com/paypal/selion/platform/html/support/events/ElementEventListener.java
+++ b/client/src/main/java/com/paypal/selion/platform/html/support/events/ElementEventListener.java
@@ -55,6 +55,26 @@ public interface ElementEventListener {
     void afterClick(Clickable target, Object... expected);
     
     /**
+     * This event gets triggered before we take a screenshot when clicking a element. The following objects trigger this event,
+     * {@link Button}, {@link CheckBox}, {@link DatePicker}, {@link Form}, {@link Image}, {@link Label}, {@link Link},
+     * {@link RadioButton}, {@link SelectList}, {@link Table}, {@link TextField}
+     * 
+     * @param target Instance of the element that triggered this event and implements {@link Clickable}
+     * @param expected The expected objects that were passed to the click method
+     */
+    void beforeScreenshot(Clickable target);
+    
+    /**
+     * This event gets triggered before we take a screenshot when clicking a element. The following objects trigger this event,
+     * {@link Button}, {@link CheckBox}, {@link DatePicker}, {@link Form}, {@link Image}, {@link Label}, {@link Link},
+     * {@link RadioButton}, {@link SelectList}, {@link Table}, {@link TextField}
+     * 
+     * @param target Instance of the element that triggered this event and implements {@link Clickable}
+     * @param expected The expected objects that were passed to the click method
+     */
+    void afterScreenshot(Clickable target);
+    
+    /**
      * This event gets triggered before we start typing in an element. The following objects trigger this event,
      * {@link TextField}
      * 
@@ -263,4 +283,5 @@ public interface ElementEventListener {
      * @param expected The expected objects that were passed to the hover method
      */
     void afterHover(Hoverable target, Object... expected);
+
 }

--- a/client/src/test/java/com/paypal/selion/platform/html/support/events/ElementListenerTestImpl.java
+++ b/client/src/test/java/com/paypal/selion/platform/html/support/events/ElementListenerTestImpl.java
@@ -36,6 +36,22 @@ public class ElementListenerTestImpl implements ElementEventListener {
         
         page.getLogLabel().setProperty("data-after-click", "true");
     }
+    
+    @Override
+    public void beforeScreenshot(Clickable target) {
+        AbstractElement element = (AbstractElement) target;
+        TestPage page = (TestPage) element.getParent().getCurrentPage();
+        
+        page.getLogLabel().setProperty("data-before-screenshot", "true");
+    }
+
+    @Override
+    public void afterScreenshot(Clickable target) {
+        AbstractElement element = (AbstractElement) target;
+        TestPage page = (TestPage) element.getParent().getCurrentPage();
+        
+        page.getLogLabel().setProperty("data-after-screenshot", "true");
+    }
 
     @Override
     public void beforeType(Typeable target, String value) {


### PR DESCRIPTION
We need this method to make changes to the webpage before a screenshot gets taken. SeLion by default takes screenshots of the whole page (which we love). But a lot of websites nowadays are using floating headers/elements, this means that when the page is scrolled the header shows in the middle of the page. 

This becomes a problem for the QA's that review the screenshots, with this change we can add a scroll up before the screenshot gets take, and scroll down afterwards.
