### PR TITLE
Add browser load monitoring servlet

### DIFF
--- a/server/src/main/java/com/paypal/selion/grid/servlets/GridStatistics.java
+++ b/server/src/main/java/com/paypal/selion/grid/servlets/GridStatistics.java
@@ -1,0 +1,152 @@
+/*-------------------------------------------------------------------------------------------------------------------*\
+|  Copyright (C) 2016 PayPal                                                                                          |
+|                                                                                                                     |
+|  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
+|  with the License.                                                                                                  |
+|                                                                                                                     |
+|  You may obtain a copy of the License at                                                                            |
+|                                                                                                                     |
+|       http://www.apache.org/licenses/LICENSE-2.0                                                                    |
+|                                                                                                                     |
+|  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed   |
+|  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for  |
+|  the specific language governing permissions and limitations under the License.                                     |
+\*-------------------------------------------------------------------------------------------------------------------*/
+
+package com.paypal.selion.grid.servlets;
+
+import java.io.IOException;
+import java.util.List;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.openqa.grid.internal.Registry;
+import org.openqa.grid.web.servlet.RegistryBasedServlet;
+import org.openqa.selenium.remote.DesiredCapabilities;
+
+import com.paypal.selion.pojos.BrowserInformationCache;
+import com.paypal.selion.pojos.BrowserStatisticsCollection;
+import com.paypal.selion.pojos.BrowserStatisticsCollection.BrowserStatistics;
+import com.paypal.selion.utils.ServletHelper;
+import com.paypal.selion.proxy.SeLionRemoteProxy;
+
+/**
+ * <code>GridStatistics</code> servlet displays the current load on the Grid per browser, i.e., the number of requests
+ * waiting on the queue for a browser and the maximum instances of that browser. The servlet responds only to client
+ * using accept header for all media types and accept header of type application/json. This servlet should be injected
+ * into the Grid. This servlet <strong>requires</strong> the remote proxies to update the {@link BrowserInformationCache}
+ * upon initialization. Any {@link SeLionRemoteProxy} performs this required update.<br>
+ * 
+ * <pre>
+ * cURL clients
+ * 
+ * Sample requests
+ * curl -s http://<domain>:<port>/grid/admin/GridStatistics
+ * curl -s -X GET http://<domain>:<port>/grid/admin/GridStatistics
+ * curl -s -H "Accept: application/json" -X GET http://<domain>:<port>/grid/admin/GridStatistics
+ * 
+ * Browser clients
+ * 
+ * Go to the URL http://<domain>:<port>/grid/admin/GridStatistics
+ * 
+ * Sample response
+ * [{
+ *     "browserName": "chrome",
+ *     "statistics": {
+ *         "waitingRequests": 2,
+ *         "maxBrowserInstances": 10
+ *     }
+ * },
+ * {
+ *     "browserName": "firefox",
+ *     "statistics": {
+ *         "waitingRequests": 3,
+ *         "maxBrowserInstances": 15
+ *     }
+ * },
+ * {
+ *     "browserName": "internet explorer",
+ *     "statistics": {
+ *         "waitingRequests": 0,
+ *         "maxBrowserInstances": 1
+ *     }
+ * }]
+ * </pre>
+ */
+public class GridStatistics extends RegistryBasedServlet {
+
+    /**
+     * Serial Version ID
+     */
+    private static final long serialVersionUID = -4200130800419092658L;
+
+    public GridStatistics() {
+        this(null);
+    }
+
+    public GridStatistics(Registry registry) {
+        super(registry);
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        process(request, response);
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        process(req, resp);
+    }
+
+    /**
+     * This method gets a list of {@link BrowserStatistics} and returns over HTTP as a json document
+     *
+     * @param request
+     *            {@link HttpServletRequest} that represents the servlet request
+     * @param response
+     *            {@link HttpServletResponse} that represents the servlet response
+     * @throws IOException
+     */
+    protected void process(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        String acceptHeader = request.getHeader("Accept");
+        if (acceptHeader != null && ((acceptHeader.contains("*/*")) || (acceptHeader.contains("application/json")))) {
+            ServletHelper.respondAsJsonWithHttpStatus(response, getGridLoadResponse(), HttpServletResponse.SC_OK);
+        } else {
+            response.sendError(HttpServletResponse.SC_NOT_ACCEPTABLE,
+                    "The servlet can only respond to application/json or */* Accept headers");
+        }
+    }
+
+    private List<BrowserStatistics> getGridLoadResponse() {
+        BrowserStatisticsCollection gridStatisticsCollection = getBrowserMaxStatistics();
+        updateWaitingRequests(gridStatisticsCollection);
+        return gridStatisticsCollection.getBrowserStatisticsList();
+    }
+
+    private BrowserStatisticsCollection getBrowserMaxStatistics() {
+        BrowserStatisticsCollection browserStatisticsCollection = new BrowserStatisticsCollection();
+        BrowserInformationCache browserInformationCache = BrowserInformationCache.getInstance();
+        for (String browserName : BrowserInformationCache.SUPPORTED_BROWSERS) {
+            int totalBrowserCapacity = browserInformationCache.getTotalBrowserCapacity(browserName, getRegistry());
+            if (totalBrowserCapacity > 0) {
+                browserStatisticsCollection.setMaxBrowserInstances(browserName, totalBrowserCapacity);
+            }
+        }
+        return browserStatisticsCollection;
+    }
+
+    private void updateWaitingRequests(BrowserStatisticsCollection gridStatistics) {
+        String capabilitiesBrowserName;
+        for (DesiredCapabilities waitingCapabilities : this.getRegistry().getDesiredCapabilities()) {
+            capabilitiesBrowserName = waitingCapabilities.getBrowserName();
+            for (String browserName : BrowserInformationCache.SUPPORTED_BROWSERS) {
+                if (capabilitiesBrowserName.startsWith(browserName)) {
+                    gridStatistics.incrementWaitingRequests(browserName);
+                }
+            }
+        }
+    }
+
+}

--- a/server/src/main/java/com/paypal/selion/pojos/BrowserInformationCache.java
+++ b/server/src/main/java/com/paypal/selion/pojos/BrowserInformationCache.java
@@ -1,0 +1,256 @@
+/*-------------------------------------------------------------------------------------------------------------------*\
+|  Copyright (C) 2016 PayPal                                                                                          |
+|                                                                                                                     |
+|  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
+|  with the License.                                                                                                  |
+|                                                                                                                     |
+|  You may obtain a copy of the License at                                                                            |
+|                                                                                                                     |
+|       http://www.apache.org/licenses/LICENSE-2.0                                                                    |
+|                                                                                                                     |
+|  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed   |
+|  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for  |
+|  the specific language governing permissions and limitations under the License.                                     |
+\*-------------------------------------------------------------------------------------------------------------------*/
+
+package com.paypal.selion.pojos;
+
+import java.lang.reflect.Field;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+
+import org.openqa.grid.internal.Registry;
+import org.openqa.grid.internal.RemoteProxy;
+
+import com.paypal.selion.logging.SeLionGridLogger;
+
+/**
+ * <code>BrowserInformationCache</code> acts as a cache holding the browser name and the maximum instances available in
+ * a particular node. The key to the cache is the {@link URL} object of the node that uniquely identifies the node.
+ */
+public class BrowserInformationCache {
+
+    public static final String[] SUPPORTED_BROWSERS;
+
+    private static final int INITIAL_CAPACITY = 25;
+
+    private static final SeLionGridLogger logger = SeLionGridLogger.getLogger(BrowserInformationCache.class);
+
+    private static final BrowserInformationCache instance = new BrowserInformationCache();
+
+    private final Map<URL, TestSlotInformation> nodeMap;
+    
+    static {
+        List<String> browserList = new ArrayList<>();
+        try {
+            Class<?> clazz = Class.forName("org.openqa.selenium.remote.BrowserType");
+            Field[] fields = clazz.getDeclaredFields();
+            for (Field field : fields) {
+                if (field.getAnnotation(Deprecated.class) == null) {
+                    browserList.add(field.get(null).toString());
+                }
+            }
+        } catch (Exception e) {
+            browserList.clear();
+            browserList.addAll(Arrays.asList("android", "chrome", "firefox", "htmlunit",
+                "internet explorer", "iPhone", "iPad", "opera", "safari", "MicrosoftEdge"));
+        } finally {
+            SUPPORTED_BROWSERS = browserList.toArray(new String[0]);
+        }
+    }
+
+    private BrowserInformationCache() {
+        nodeMap = new ConcurrentHashMap<>(INITIAL_CAPACITY);
+    }
+
+    public static BrowserInformationCache getInstance() {
+        return instance;
+    }
+
+    /**
+     * Updates the Cache for the provide Node represented by the {@link URL} instance. This methods creates or updates
+     * information for the Node/Browser combination.
+     * 
+     * @param url
+     *            {@link URL} of the Node.
+     * @param browserName
+     *            Browser name as {@link String}.
+     * @param maxInstances
+     *            Maximum instances of the browser.
+     */
+    public synchronized void updateBrowserInfo(URL url, String browserName, int maxInstances) {
+        logger.entering(new Object[] { url, browserName, maxInstances });
+        BrowserInformation browserInformation = BrowserInformation.createBrowserInfo(browserName, maxInstances);
+        TestSlotInformation testSlotInformation = (nodeMap.get(url) == null) ? new TestSlotInformation() : nodeMap
+                .get(url);
+        testSlotInformation.addBrowserInfo(browserInformation);
+        if (nodeMap.get(url) == null) {
+            logger.log(Level.FINE, "Creating new entry -> " + url + " : [" + browserName + ":" + maxInstances + "]");
+            nodeMap.put(url, testSlotInformation);
+        } else {
+            logger.log(Level.FINE, "Added entry -> " + url + " : " + " : [" + browserName + ":" + maxInstances + "]");
+        }
+    }
+
+    /**
+     * Returns the total instances of a particular browser, available through all nodes. This methods takes an instance
+     * of {@link Registry} to clean the cache before returning the results.
+     * 
+     * @param browserName
+     *            Browser name as {@link String}
+     * @param registry
+     *            {@link Registry} instance.
+     * @return Total instances of a particular browser across nodes.
+     */
+    public synchronized int getTotalBrowserCapacity(String browserName, Registry registry) {
+        logger.entering(new Object[] { browserName, registry });
+        cleanCacheUsingRegistry(registry);
+        int totalBrowserCounts = 0;
+        for (Map.Entry<URL, TestSlotInformation> entry : nodeMap.entrySet()) {
+            BrowserInformation browserInfo = entry.getValue().getBrowserInfo(browserName);
+            totalBrowserCounts += (browserInfo == null) ? 0 : browserInfo.getMaxInstances();
+        }
+        logger.exiting(totalBrowserCounts);
+        return totalBrowserCounts;
+    }
+
+    private void cleanCacheUsingRegistry(Registry registry) {
+        List<URL> relevantURLs = getRegistryURLs(registry);
+        removeIrrelevantURLs(relevantURLs);
+    }
+
+    private List<URL> getRegistryURLs(Registry registry) {
+        Iterator<RemoteProxy> remoteProxyIterator = registry.getAllProxies().iterator();
+        List<URL> urlList = new ArrayList<>();
+        while (remoteProxyIterator.hasNext()) {
+            RemoteProxy remoteProxy = remoteProxyIterator.next();
+            urlList.add(remoteProxy.getRemoteHost());
+        }
+        return urlList;
+    }
+
+    private void removeIrrelevantURLs(List<URL> hotURLList) {
+        Iterator<URL> urlIterator = nodeMap.keySet().iterator();
+        while (urlIterator.hasNext()) {
+            URL cacheURL = urlIterator.next();
+            if (!hotURLList.contains(cacheURL)) {
+                nodeMap.remove(cacheURL);
+            }
+        }
+    }
+
+    /**
+     * <code>TestSlotInformation</code> holds the {@link BrowserInformation} corresponding to a individual unique test
+     * slot.
+     */
+    private static class TestSlotInformation {
+
+        private static final SeLionGridLogger logger = SeLionGridLogger.getLogger(TestSlotInformation.class);
+
+        // Browser information set.
+        private final Set<BrowserInformation> browserInformationSet;
+
+        private TestSlotInformation() {
+            browserInformationSet = new HashSet<>();
+        }
+
+        /**
+         * Updates the BrowserInformation. This method removes the existing entry and updates with the new entry.
+         * 
+         * @param browserInformation
+         *            Instance of {@link BrowserInformation}
+         * @return True if addition is successful, false otherwise.
+         */
+        private boolean addBrowserInfo(BrowserInformation browserInformation) {
+            logger.entering(browserInformation);
+            if (!browserInformationSet.contains(browserInformation)) {
+                logger.log(Level.INFO, "Adding BrowserInfo " + browserInformation + " to set...");
+                return browserInformationSet.add(browserInformation);
+            } else {
+                logger.log(Level.INFO, "BrowserInfo " + browserInformation + " already present in set, replacing...");
+                browserInformationSet.remove(browserInformation);
+                return browserInformationSet.add(browserInformation);
+            }
+        }
+
+        private BrowserInformation getBrowserInfo(String browserName) {
+            logger.entering(browserName);
+            for (BrowserInformation browserInformation : browserInformationSet) {
+                if (browserInformation.getBrowserName().equals(browserName)) {
+                    logger.exiting(browserInformation);
+                    return browserInformation;
+                }
+            }
+            logger.log(Level.FINE, "requested browser name " + browserName + " unavailable in set... returning null");
+            return null;
+        }
+
+    }
+
+    /**
+     * Pojo for holding browser information
+     */
+    private static class BrowserInformation {
+
+        // Name of the browser
+        private final String browserName;
+
+        // Maximum instances
+        private final int maxInstances;
+
+        private volatile int calculatedHashCode;
+
+        private BrowserInformation(String browserName, int maxInstances) {
+            this.browserName = browserName;
+            this.maxInstances = maxInstances;
+        }
+
+        private static BrowserInformation createBrowserInfo(String browserName, int maxInstances) {
+            BrowserInformation browserInfo = new BrowserInformation(browserName, maxInstances);
+            return browserInfo;
+        }
+
+        public String getBrowserName() {
+            return browserName;
+        }
+
+        public int getMaxInstances() {
+            return maxInstances;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof BrowserInformation)) {
+                return false;
+            }
+            return this.getBrowserName().equals(((BrowserInformation) o).getBrowserName());
+        }
+
+        @Override
+        public int hashCode() {
+            int result = calculatedHashCode;
+            if (result == 0) {
+                result = 17;
+                result = 31 * result + getBrowserName().hashCode();
+                calculatedHashCode = result;
+            }
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return "[" + browserName + ":" + maxInstances + "]";
+        }
+    }
+}

--- a/server/src/main/java/com/paypal/selion/pojos/BrowserStatisticsCollection.java
+++ b/server/src/main/java/com/paypal/selion/pojos/BrowserStatisticsCollection.java
@@ -1,0 +1,143 @@
+/*-------------------------------------------------------------------------------------------------------------------*\
+|  Copyright (C) 2016 PayPal                                                                                          |
+|                                                                                                                     |
+|  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
+|  with the License.                                                                                                  |
+|                                                                                                                     |
+|  You may obtain a copy of the License at                                                                            |
+|                                                                                                                     |
+|       http://www.apache.org/licenses/LICENSE-2.0                                                                    |
+|                                                                                                                     |
+|  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed   |
+|  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for  |
+|  the specific language governing permissions and limitations under the License.                                     |
+\*-------------------------------------------------------------------------------------------------------------------*/
+
+package com.paypal.selion.pojos;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
+
+import com.google.gson.Gson;
+import com.paypal.selion.logging.SeLionGridLogger;
+
+/**
+ * <code>BrowserStatisticsCollection</code> stores the all the supported browsers by the Grid and Nodes collectively. It
+ * stores the maximum available instances of a particular browser in the Grid - Nodes farm along with the waiting
+ * requests for a particular browser. This class is not thread safe, the clients are expected to create individual
+ * instances of this class in separate threads.
+ * 
+ */
+public class BrowserStatisticsCollection {
+
+    private static final SeLionGridLogger logger = SeLionGridLogger.getLogger(BrowserStatisticsCollection.class);
+
+    private final List<BrowserStatistics> browserStatisticsList;
+
+    public BrowserStatisticsCollection() {
+        browserStatisticsList = new ArrayList<>();
+    }
+
+    /**
+     * Returns the list of {@link BrowserStatistics}.
+     * 
+     * @return {@link List} of {@link BrowserStatistics}.
+     */
+    public List<BrowserStatistics> getBrowserStatisticsList() {
+        return browserStatisticsList;
+    }
+
+    /**
+     * Sets the maximum instances for a particular browser. This call creates a unique statistics for the provided
+     * browser name it does not exists.
+     * 
+     * @param browserName
+     *            Name of the browser.
+     * @param maxBrowserInstances
+     *            Maximum instances of the browser.
+     */
+    public void setMaxBrowserInstances(String browserName, int maxBrowserInstances) {
+        logger.entering(new Object[] { browserName, maxBrowserInstances });
+        validateBrowserName(browserName);
+        BrowserStatistics lStatistics = createStatisticsIfNotPresent(browserName);
+        lStatistics.setMaxBrowserInstances(maxBrowserInstances);
+        logger.exiting();
+    }
+
+    /**
+     * Increments the waiting request for the provided browser name. This call creates a unique statistics for the
+     * provided browser name it does not exists.
+     * 
+     * @param browserName
+     *            Name of the browser.
+     */
+    public void incrementWaitingRequests(String browserName) {
+        logger.entering(browserName);
+        validateBrowserName(browserName);
+        BrowserStatistics lStatistics = createStatisticsIfNotPresent(browserName);
+        lStatistics.incrementWaitingRequests();
+        logger.exiting();
+    }
+
+    private void validateBrowserName(String browserName) {
+        if (StringUtils.isBlank(browserName)) {
+            throw new IllegalArgumentException("Browser name cannot be null");
+        }
+    }
+
+    private synchronized BrowserStatistics createStatisticsIfNotPresent(String browserName) {
+        for (BrowserStatistics loadStatistics : browserStatisticsList) {
+            if (loadStatistics.browserName.equals(browserName)) {
+                return loadStatistics;
+            }
+        }
+        BrowserStatistics loadStatistics = new BrowserStatistics(browserName);
+        this.browserStatisticsList.add(loadStatistics);
+        return loadStatistics;
+    }
+
+    @Override
+    public String toString() {
+        Gson gson = new Gson();
+        return gson.toJson(browserStatisticsList);
+    }
+
+    /**
+     * <code>BrowserStatistics</code> holds the statistics for an individual browser. This class acts as a mere Value
+     * Object.
+     * 
+     */
+    public class BrowserStatistics {
+        private final String browserName;
+        private final Statistics statistics;
+
+        public BrowserStatistics(String browserName) {
+            this.browserName = browserName;
+            statistics = new Statistics();
+        }
+
+        public void setMaxBrowserInstances(int maxBrowserInstances) {
+            statistics.setMaxBrowserInstances(maxBrowserInstances);
+        }
+
+        public void incrementWaitingRequests() {
+            statistics.incrementWaitingRequests();
+        }
+
+        private class Statistics {
+            int waitingRequests;
+            int maxBrowserInstances;
+
+            void setMaxBrowserInstances(int maxBrowserInstances) {
+                this.maxBrowserInstances = maxBrowserInstances;
+            }
+
+            void incrementWaitingRequests() {
+                this.waitingRequests += 1;
+            }
+        }
+    }
+
+}

--- a/server/src/main/resources/config/hubConfig.json
+++ b/server/src/main/resources/config/hubConfig.json
@@ -2,6 +2,7 @@
     "servlets": [
         "com.paypal.selion.grid.servlets.LoginServlet",
         "com.paypal.selion.grid.servlets.ListAllNodes",
+        "com.paypal.selion.grid.servlets.GridStatistics",
         "com.paypal.selion.grid.servlets.GridAutoUpgradeDelegateServlet",
         "com.paypal.selion.grid.servlets.GridForceRestartDelegateServlet",
         "com.paypal.selion.grid.servlets.PasswordChangeServlet",

--- a/server/src/test/java/com/paypal/selion/grid/servlets/GridStatisticsTest.java
+++ b/server/src/test/java/com/paypal/selion/grid/servlets/GridStatisticsTest.java
@@ -1,0 +1,74 @@
+/*-------------------------------------------------------------------------------------------------------------------*\
+|  Copyright (C) 2016 PayPal                                                                                          |
+|                                                                                                                     |
+|  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
+|  with the License.                                                                                                  |
+|                                                                                                                     |
+|  You may obtain a copy of the License at                                                                            |
+|                                                                                                                     |
+|       http://www.apache.org/licenses/LICENSE-2.0                                                                    |
+|                                                                                                                     |
+|  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed   |
+|  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for  |
+|  the specific language governing permissions and limitations under the License.                                     |
+\*-------------------------------------------------------------------------------------------------------------------*/
+
+package com.paypal.selion.grid.servlets;
+
+import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.powermock.api.support.membermodification.MemberMatcher.method;
+import static org.powermock.api.support.membermodification.MemberModifier.stub;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.testng.PowerMockTestCase;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.paypal.selion.pojos.BrowserStatisticsCollection;
+import com.paypal.selion.pojos.BrowserStatisticsCollection.BrowserStatistics;
+
+/**
+ * Tests for GridStatistics servlet
+ */
+@PrepareForTest({ GridStatistics.class })
+public class GridStatisticsTest extends PowerMockTestCase {
+
+    @Test
+    public void testValidResponse() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Accept", "*/*");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        List<BrowserStatistics> browserStatisticsList = new ArrayList<>();
+        BrowserStatisticsCollection t = new BrowserStatisticsCollection();
+        BrowserStatistics browserStatistics = t.new BrowserStatistics("chrome");
+        browserStatisticsList.add(browserStatistics);
+        spy(GridStatistics.class);
+        stub(method(GridStatistics.class, "getGridLoadResponse")).toReturn(browserStatisticsList);
+        GridStatistics gridStatistics = new GridStatistics();
+        gridStatistics.doPost(request, response);
+        Assert.assertEquals(response.getContentAsString(),
+                "[{\"browserName\":\"chrome\",\"statistics\":{\"waitingRequests\":0,\"maxBrowserInstances\":0}}]",
+                "Servlet output not matching");
+
+    }
+
+    @Test
+    public void testEmptyResponse() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Accept", "*/*");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        List<BrowserStatistics> browserStatisticsList = new ArrayList<>();
+        spy(GridStatistics.class);
+        stub(method(GridStatistics.class, "getGridLoadResponse")).toReturn(browserStatisticsList);
+        GridStatistics gridStatistics = new GridStatistics();
+        gridStatistics.doPost(request, response);
+        Assert.assertEquals(response.getContentAsString(), "[]", "Servlet output not matching");
+
+    }
+
+}


### PR DESCRIPTION
- Add GridStatistics servlet to monitor browser load
- Add maximum instances of every browser type in response
- Add number of requests waiting on queue per browser type in response
- Add support for JSON responses
- Add supporting classes BrowserInformationCache and BrowserStatisticsCollection
- Include GridStatistics servlet in hubConfig.json
