### PR TITLE
Support for selenium 2.52.0, java-client 3.3.0, and more

### DIFF
--- a/client/src/test/java/com/paypal/selion/platform/html/support/events/ElementEventTest.java
+++ b/client/src/test/java/com/paypal/selion/platform/html/support/events/ElementEventTest.java
@@ -1,5 +1,5 @@
 /*-------------------------------------------------------------------------------------------------------------------*\
-|  Copyright (C) 2014 PayPal                                                                                          |
+|  Copyright (C) 2014-2016 PayPal                                                                                     |
 |                                                                                                                     |
 |  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
 |  with the License.                                                                                                  |
@@ -27,7 +27,7 @@ import com.paypal.selion.platform.grid.Grid;
 import com.paypal.selion.testcomponents.TestPage;
 
 public class ElementEventTest {
-    
+
     @Test(groups = { "functional" })
     @WebTest
     public void testClickEvents() throws InterruptedException, IOException {
@@ -35,14 +35,16 @@ public class ElementEventTest {
         String script = getScript();
         Grid.driver().executeScript(script);
         Thread.sleep(4000);
-        
+
         Grid.getTestSession().getElementEventListeners().add(new ElementListenerTestImpl());
 
         TestPage page = new TestPage("US");
 
         page.clickContinueButton(page);
-        Assert.assertEquals(page.getLogLabel().getProperty("data-before-click"), "true", "beforeClick method was not triggered.");
-        Assert.assertEquals(page.getLogLabel().getProperty("data-after-click"), "true", "afterClick method was not triggered.");
+        Assert.assertEquals(page.getLogLabel().getProperty("data-before-click"), "true",
+                "beforeClick method was not triggered.");
+        Assert.assertEquals(page.getLogLabel().getProperty("data-after-click"), "true",
+                "afterClick method was not triggered.");
     }
 
     @Test(groups = { "functional" })
@@ -58,8 +60,10 @@ public class ElementEventTest {
         TestPage page = new TestPage("US");
 
         page.getContinueButton().hover();
-        Assert.assertEquals(page.getLogLabel().getProperty("data-before-hover"), "true", "beforeHover method was not triggered.");
-        Assert.assertEquals(page.getLogLabel().getProperty("data-after-hover"), "true", "afterHover method was not triggered.");
+        Assert.assertEquals(page.getLogLabel().getProperty("data-before-hover"), "true",
+                "beforeHover method was not triggered.");
+        Assert.assertEquals(page.getLogLabel().getProperty("data-after-hover"), "true",
+                "afterHover method was not triggered.");
     }
 
     @Test(groups = { "functional" })
@@ -69,16 +73,18 @@ public class ElementEventTest {
         String script = getScript();
         Grid.driver().executeScript(script);
         Thread.sleep(4000);
-        
+
         Grid.getTestSession().getElementEventListeners().add(new ElementListenerTestImpl());
 
         TestPage page = new TestPage("US");
 
         page.setFieldXTextFieldValue("Test");
-        Assert.assertEquals(page.getLogLabel().getProperty("data-before-type"), "true", "beforeType method was not triggered.");
-        Assert.assertEquals(page.getLogLabel().getProperty("data-after-type"), "true", "afterType method was not triggered.");
+        Assert.assertEquals(page.getLogLabel().getProperty("data-before-type"), "true",
+                "beforeType method was not triggered.");
+        Assert.assertEquals(page.getLogLabel().getProperty("data-after-type"), "true",
+                "afterType method was not triggered.");
     }
-    
+
     @Test(groups = { "functional" })
     @WebTest
     public void testSelectEvents() throws InterruptedException, IOException {
@@ -86,19 +92,23 @@ public class ElementEventTest {
         String script = getScript();
         Grid.driver().executeScript(script);
         Thread.sleep(4000);
-        
+
         Grid.getTestSession().getElementEventListeners().add(new ElementListenerTestImpl());
 
         TestPage page = new TestPage("US");
 
         page.getXSelectList().selectByIndex(1);
         page.getXSelectList().deselectByIndex(1);
-        Assert.assertEquals(page.getLogLabel().getProperty("data-before-select"), "true", "beforeSelect method was not triggered.");
-        Assert.assertEquals(page.getLogLabel().getProperty("data-after-select"), "true", "afterSelect method was not triggered.");
-        Assert.assertEquals(page.getLogLabel().getProperty("data-before-deselect"), "true", "beforeDeselect method was not triggered.");
-        Assert.assertEquals(page.getLogLabel().getProperty("data-after-deselect"), "true", "afterDeselect method was not triggered.");
+        Assert.assertEquals(page.getLogLabel().getProperty("data-before-select"), "true",
+                "beforeSelect method was not triggered.");
+        Assert.assertEquals(page.getLogLabel().getProperty("data-after-select"), "true",
+                "afterSelect method was not triggered.");
+        Assert.assertEquals(page.getLogLabel().getProperty("data-before-deselect"), "true",
+                "beforeDeselect method was not triggered.");
+        Assert.assertEquals(page.getLogLabel().getProperty("data-after-deselect"), "true",
+                "afterDeselect method was not triggered.");
     }
-    
+
     @Test(groups = { "functional" })
     @WebTest
     public void testCheckEvents() throws InterruptedException, IOException {
@@ -106,26 +116,31 @@ public class ElementEventTest {
         String script = getScript();
         Grid.driver().executeScript(script);
         Thread.sleep(4000);
-        
+
         Grid.getTestSession().getElementEventListeners().add(new ElementListenerTestImpl());
 
         TestPage page = new TestPage("US");
 
         page.getXCheckBox().check();
         page.getXCheckBox().uncheck();
-        
-        Assert.assertEquals(page.getLogLabel().getProperty("data-before-check"), "true", "beforeCheck method was not triggered.");
-        Assert.assertEquals(page.getLogLabel().getProperty("data-after-check"), "true", "afterCheck method was not triggered.");
-        Assert.assertEquals(page.getLogLabel().getProperty("data-before-uncheck"), "true", "beforeUncheck method was not triggered.");
-        Assert.assertEquals(page.getLogLabel().getProperty("data-after-uncheck"), "true", "afterUncheck method was not triggered.");
-        
-        //Reset the events triggered for RadioButton testing
+
+        Assert.assertEquals(page.getLogLabel().getProperty("data-before-check"), "true",
+                "beforeCheck method was not triggered.");
+        Assert.assertEquals(page.getLogLabel().getProperty("data-after-check"), "true",
+                "afterCheck method was not triggered.");
+        Assert.assertEquals(page.getLogLabel().getProperty("data-before-uncheck"), "true",
+                "beforeUncheck method was not triggered.");
+        Assert.assertEquals(page.getLogLabel().getProperty("data-after-uncheck"), "true",
+                "afterUncheck method was not triggered.");
+
+        // Reset the events triggered for RadioButton testing
         page.getLogLabel().setProperty("data-before-check", null);
         page.getLogLabel().setProperty("data-after-check", null);
-        
+
         page.getXRadioButton().check();
-        
-        Assert.assertEquals(page.getLogLabel().getProperty("data-before-check"), "true", "beforeCheck method was not triggered.");
+
+        Assert.assertEquals(page.getLogLabel().getProperty("data-before-check"), "true",
+                "beforeCheck method was not triggered.");
         Assert.assertEquals(page.getLogLabel().getProperty("data-after-check"), "true",
                 "afterType method was not triggered.");
     }

--- a/client/src/test/resources/testdata/InsertHtmlElements.js
+++ b/client/src/test/resources/testdata/InsertHtmlElements.js
@@ -55,6 +55,7 @@ document.body.appendChild(radio);
 
 var select = document.createElement("select");
 select.id = "select"
+select.multiple = true;
 
 var option1 = document.createElement("option");
 option1.innerHTML = "Option 1";

--- a/codegen/pom.xml
+++ b/codegen/pom.xml
@@ -86,6 +86,11 @@
         </dependency>
 
         <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -15,11 +15,11 @@
         <compileSource>1.7</compileSource>
         <skipTests>false</skipTests>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <selenium.version>2.48.2</selenium.version>
+        <selenium.version>2.52.0</selenium.version>
         <iosdriver.version>0.6.5</iosdriver.version>
         <selendroid.version>0.17.0</selendroid.version>
-        <appium.version>3.2.0</appium.version>
-        <testng.version>6.9.6</testng.version>
+        <appium.version>3.3.0</appium.version>
+        <testng.version>6.9.10</testng.version>
         <snakeyaml.version>1.15</snakeyaml.version>
         <project.bom.version>${project.version}</project.bom.version>
     </properties>

--- a/project-bom/pom.xml
+++ b/project-bom/pom.xml
@@ -77,6 +77,12 @@
             </dependency>
 
             <dependency>
+                <groupId>commons-collections</groupId>
+                <artifactId>commons-collections</artifactId>
+                <version>3.2.2</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
                 <version>4.5.1</version>
@@ -109,7 +115,7 @@
             <dependency>
                 <artifactId>guava</artifactId>
                 <groupId>com.google.guava</groupId>
-                <version>18.0</version>
+                <version>19.0</version>
             </dependency>
 
             <!-- TestNG -->
@@ -231,6 +237,10 @@
                     <exclusion>
                         <artifactId>httpclient</artifactId>
                         <groupId>org.apache.httpcomponents</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-collections</groupId>
+                        <artifactId>commons-collections</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -363,6 +373,10 @@
                         <groupId>commons-lang</groupId>
                         <artifactId>commons-lang</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>commons-collections</groupId>
+                        <artifactId>commons-collections</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 
@@ -392,6 +406,10 @@
                     <exclusion>
                         <artifactId>junit</artifactId>
                         <groupId>junit</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-collections</groupId>
+                        <artifactId>commons-collections</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/server/src/main/java/com/paypal/selion/grid/FileDownloader.java
+++ b/server/src/main/java/com/paypal/selion/grid/FileDownloader.java
@@ -215,7 +215,8 @@ final class FileDownloader {
             if (result.endsWith(".msi")) {
                 String extractedExeFile = FileExtractor.extractMsi(result);
                 files.add(extractedExeFile);
-            } else if (!result.endsWith(".jar") && !result.endsWith(".msi")) {
+            }
+            if (!result.endsWith(".jar") && !result.endsWith(".msi")) {
                 List<String> extractedFileList = FileExtractor.extractArchive(result);
                 files.addAll(extractedFileList);
             }

--- a/server/src/main/java/com/paypal/selion/grid/FileExtractor.java
+++ b/server/src/main/java/com/paypal/selion/grid/FileExtractor.java
@@ -60,18 +60,13 @@ final class FileExtractor {
      */
     static List<String> getExecutableNames() {
         List<String> executableNames = new ArrayList<String>();
-        switch (Platform.getCurrent()) {
-        case WINDOWS: {
+        if (Platform.getCurrent().is(Platform.WINDOWS)) {
             Collections.addAll(executableNames, ProcessNames.PHANTOMJS.getWindowsImageName(),
                     ProcessNames.CHROMEDRIVER.getWindowsImageName(), ProcessNames.IEDRIVER.getWindowsImageName(),
                     ProcessNames.EDGEDRIVER.getWindowsImageName());
-            break;
-        }
-        default: {
+        } else {
             Collections.addAll(executableNames, ProcessNames.PHANTOMJS.getUnixImageName(),
                     ProcessNames.CHROMEDRIVER.getUnixImageName());
-            break;
-        }
         }
         return executableNames;
     }

--- a/server/src/main/java/com/paypal/selion/grid/servlets/PasswordChangeServlet.java
+++ b/server/src/main/java/com/paypal/selion/grid/servlets/PasswordChangeServlet.java
@@ -49,7 +49,7 @@ public class PasswordChangeServlet extends HttpServlet {
     public static final String NEW_PASSWORD_1 = "newPassword1";
 
     /**
-     * Form parameter for the new password (seconde entry)
+     * Form parameter for the new password (second entry)
      */
     public static final String NEW_PASSWORD_2 = "newPassword2";
 

--- a/server/src/main/resources/config/download.json
+++ b/server/src/main/resources/config/download.json
@@ -3,24 +3,24 @@
     "name": "selenium",
     "roles": [ "node", "hub", "standalone", "sauce" ],
     "any": {
-      "url": "https://selenium-release.storage.googleapis.com/2.48/selenium-server-standalone-2.48.2.jar",
-      "checksum": "b2784fc67c149d3c13c83d2108104689"
+      "url": "https://selenium-release.storage.googleapis.com/2.52/selenium-server-standalone-2.52.0.jar",
+      "checksum": "30aa6d207e530a3c25fc3c12ea968a8d"
     }
   },
   {
     "name": "chromedriver",
     "roles": [ "node", "standalone" ],
     "windows": {
-      "url": "https://chromedriver.storage.googleapis.com/2.20/chromedriver_win32.zip",
-      "checksum": "028ee452b8e23890ec5ec6b0717fd295"
+      "url": "https://chromedriver.storage.googleapis.com/2.21/chromedriver_win32.zip",
+      "checksum": "8a93dc3ff02ef9bc3161dd4b20f87215"
     },
     "linux": {
-      "url": "https://chromedriver.storage.googleapis.com/2.20/chromedriver_linux64.zip",
-      "checksum": "245858cc984bd946df6a1e6719c8e6f5"
+      "url": "https://chromedriver.storage.googleapis.com/2.21/chromedriver_linux64.zip",
+      "checksum": "06e57f4c411e1135c6277d17ea8390fd"
     },
     "mac": {
-      "url": "https://chromedriver.storage.googleapis.com/2.20/chromedriver_mac32.zip",
-      "checksum": "749d4be0a317e92fd3aecaa022385439"
+      "url": "https://chromedriver.storage.googleapis.com/2.21/chromedriver_mac32.zip",
+      "checksum": "452d8c9cba353ba366d15fbeba013943"
     }
   },
   {
@@ -43,16 +43,16 @@
     "name": "iedriver",
     "roles": [ "node", "standalone" ],
     "windows": {
-      "url": "http://selenium-release.storage.googleapis.com/2.48/IEDriverServer_Win32_2.48.0.zip",
-      "checksum": "f7b8b07393e31d05ab360a06f51b482a"
+      "url": "http://selenium-release.storage.googleapis.com/2.52/IEDriverServer_Win32_2.52.1.zip",
+      "checksum": "0fb199d71d991dfcf65a198051016d00"
     }
   },
   {
     "name": "edgedriver",
     "roles": [ "node", "standalone" ],
     "windows": {
-      "url": "https://download.microsoft.com/download/1/4/1/14156DA0-D40F-460A-B14D-1B264CA081A5/MicrosoftWebDriver.msi",
-      "checksum": "32722bf59f09b937ea23915ea980c4b8"
+      "url": "https://download.microsoft.com/download/8/D/0/8D0D08CF-790D-4586-B726-C6469A9ED49C/MicrosoftWebDriver.msi",
+      "checksum": "524f701858a4c4ac82e4b0e496ba971ac64a5662"
     }
   },
   {

--- a/server/src/test/java/com/paypal/selion/grid/IOSDriverJarSpawnerTest.java
+++ b/server/src/test/java/com/paypal/selion/grid/IOSDriverJarSpawnerTest.java
@@ -1,5 +1,5 @@
 /*-------------------------------------------------------------------------------------------------------------------*\
-|  Copyright (C) 2015 PayPal                                                                                          |
+|  Copyright (C) 2015-2016 PayPal                                                                                     |
 |                                                                                                                     |
 |  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
 |  with the License.                                                                                                  |


### PR DESCRIPTION
-  Fix #232 - Bump support for selenium to 2.52.0
  - Fix element deselect test that requires select to be of type
    multiple select
  - _Note_: **changes will not be backwards compatible with
    selenium version < 2.49.0** .. _this is an upstream breakage_
  - _Also Note_: Users must clear or update their existing
    `${selionHome}/config/download.properties` file
- Fix #233 - Bump support for java-client to 3.3.0
- Bump guava version to 19.0
- Fix #252, #253, #254
