### PR TITLE
Add initial geckodriver /  marionette support

### DIFF
--- a/client/src/main/java/com/paypal/selion/configuration/Config.java
+++ b/client/src/main/java/com/paypal/selion/configuration/Config.java
@@ -404,6 +404,18 @@ public final class Config {
         SELENIUM_EDGEDRIVER_PATH("edgeDriverPath", "", true),
 
         /**
+         *  Flip this parameter to <code>true</code> to enable the use of Gecko/marionette driver (PKA wires) with
+         *  Firefox.  This is used for local as well as remote grid executions using Firefox browser.
+         */
+        SELENIUM_USE_GECKODRIVER("useGeckoDriver", "false", true),
+
+        /**
+         * The path to the Gecko/Marionette driver executable file on the local machine. This parameter is taken into
+         * consideration for local runs only with the Firefox browser.
+         */
+        SELENIUM_GECKODRIVER_PATH("geckoDriverPath", "", true),
+
+        /**
          * Use this parameter to set the user agent for firefox when working with Mobile version. This parameter should
          * be set in conjunction with the parameter {@link ConfigProperty#BROWSER}
          */

--- a/client/src/main/java/com/paypal/selion/internal/platform/grid/LocalNode.java
+++ b/client/src/main/java/com/paypal/selion/internal/platform/grid/LocalNode.java
@@ -140,6 +140,14 @@ final class LocalNode extends AbstractBaseLocalServerComponent {
             list.add("phantomjs");
         }
 
+        // for GeckoDriver
+        if (!checkForPresenceOf(ConfigProperty.SELENIUM_GECKODRIVER_PATH,
+                SeLionConstants.WEBDRIVER_GECKO_DRIVER_PROPERTY, SeLionConstants.GECKO_DRIVER)) {
+            Config.setConfigProperty(ConfigProperty.SELENIUM_GECKODRIVER_PATH, SeLionConstants.SELION_HOME_DIR
+                    + SeLionConstants.GECKO_DRIVER);
+            list.add("geckodriver");
+        }
+
         return list;
     }
 

--- a/client/src/main/java/com/paypal/selion/internal/platform/grid/browsercapabilities/GeckoCapabilitiesBuilder.java
+++ b/client/src/main/java/com/paypal/selion/internal/platform/grid/browsercapabilities/GeckoCapabilitiesBuilder.java
@@ -1,0 +1,50 @@
+/*-------------------------------------------------------------------------------------------------------------------*\
+|  Copyright (C) 2016 PayPal                                                                                          |
+|                                                                                                                     |
+|  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
+|  with the License.                                                                                                  |
+|                                                                                                                     |
+|  You may obtain a copy of the License at                                                                            |
+|                                                                                                                     |
+|       http://www.apache.org/licenses/LICENSE-2.0                                                                    |
+|                                                                                                                     |
+|  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed   |
+|  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for  |
+|  the specific language governing permissions and limitations under the License.                                     |
+\*-------------------------------------------------------------------------------------------------------------------*/
+package com.paypal.selion.internal.platform.grid.browsercapabilities;
+
+import com.paypal.selion.SeLionConstants;
+import com.paypal.selion.configuration.Config;
+import com.paypal.selion.configuration.Config.ConfigProperty;
+import org.apache.commons.lang.StringUtils;
+import org.openqa.selenium.remote.DesiredCapabilities;
+
+/**
+ * This class represents the capabilities that are specific to the Gecko/marionette (PKA wires) driver.
+ */
+class GeckoCapabilitiesBuilder extends FireFoxCapabilitiesBuilder {
+
+    public static final String MARIONETTE = "marionette";
+
+    @Override
+    public DesiredCapabilities getCapabilities(DesiredCapabilities capabilities) {
+        DesiredCapabilities caps = super.getCapabilities(capabilities);
+        caps.setCapability(MARIONETTE, true);
+
+        String geckoDriverPath = getBinaryPath();
+        if (isLocalRun() && StringUtils.isNotBlank(geckoDriverPath)) {
+            System.setProperty(SeLionConstants.WEBDRIVER_GECKO_DRIVER_PROPERTY, geckoDriverPath);
+        }
+        return caps;
+    }
+
+    /*
+     * Returns the location of Gecko/marionette driver or empty string if it cannot be determined.
+     */
+    private String getBinaryPath() {
+        String location = System.getProperty(SeLionConstants.WEBDRIVER_GECKO_DRIVER_PROPERTY,
+                Config.getConfigProperty(ConfigProperty.SELENIUM_GECKODRIVER_PATH));
+        return location;
+    }
+}

--- a/client/src/main/java/com/paypal/selion/internal/platform/grid/browsercapabilities/WebDriverFactory.java
+++ b/client/src/main/java/com/paypal/selion/internal/platform/grid/browsercapabilities/WebDriverFactory.java
@@ -1,5 +1,5 @@
 /*-------------------------------------------------------------------------------------------------------------------*\
-|  Copyright (C) 2015 PayPal                                                                                          |
+|  Copyright (C) 2015-2016 PayPal                                                                                          |
 |                                                                                                                     |
 |  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
 |  with the License.                                                                                                  |
@@ -56,7 +56,12 @@ public final class WebDriverFactory {
         RemoteWebDriver driver = null;
         switch (browser) {
         case FIREFOX:
-            capability = new FireFoxCapabilitiesBuilder().createCapabilities();
+            boolean useGeckoDriver = Config.getBoolConfigProperty(ConfigProperty.SELENIUM_USE_GECKODRIVER);
+            if (useGeckoDriver) {
+                capability = new GeckoCapabilitiesBuilder().createCapabilities();
+            } else {
+                capability = new FireFoxCapabilitiesBuilder().createCapabilities();
+            }
             break;
         case CHROME:
             capability = new ChromeCapabilitiesBuilder().createCapabilities();

--- a/client/src/main/java/com/paypal/selion/platform/html/support/events/ElementEventListener.java
+++ b/client/src/main/java/com/paypal/selion/platform/html/support/events/ElementEventListener.java
@@ -65,8 +65,6 @@ public interface ElementEventListener {
      * 
      * @param target
      *            Instance of the element that triggered this event and implements {@link Clickable}
-     * @param expected
-     *            The expected objects that were passed to the click method
      */
     void beforeScreenshot(Clickable target);
 
@@ -77,8 +75,6 @@ public interface ElementEventListener {
      * 
      * @param target
      *            Instance of the element that triggered this event and implements {@link Clickable}
-     * @param expected
-     *            The expected objects that were passed to the click method
      */
     void afterScreenshot(Clickable target);
 

--- a/client/src/test/java/com/paypal/selion/internal/platform/grid/browsercapabilities/CapabilitiesBuildersTest.java
+++ b/client/src/test/java/com/paypal/selion/internal/platform/grid/browsercapabilities/CapabilitiesBuildersTest.java
@@ -1,0 +1,34 @@
+/*-------------------------------------------------------------------------------------------------------------------*\
+|  Copyright (C) 2016 PayPal                                                                                          |
+|                                                                                                                     |
+|  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
+|  with the License.                                                                                                  |
+|                                                                                                                     |
+|  You may obtain a copy of the License at                                                                            |
+|                                                                                                                     |
+|       http://www.apache.org/licenses/LICENSE-2.0                                                                    |
+|                                                                                                                     |
+|  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed   |
+|  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for  |
+|  the specific language governing permissions and limitations under the License.                                     |
+\*-------------------------------------------------------------------------------------------------------------------*/
+
+package com.paypal.selion.internal.platform.grid.browsercapabilities;
+
+import org.openqa.selenium.remote.DesiredCapabilities;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertTrue;
+
+/**
+ * This class is used to test browser capabilities builder classes
+ */
+public class CapabilitiesBuildersTest {
+
+    @Test(groups = "unit")
+    public void testGeckoDriverCaps() {
+        DesiredCapabilities caps = new GeckoCapabilitiesBuilder().createCapabilities();
+        assertTrue(caps.getCapability(GeckoCapabilitiesBuilder.MARIONETTE) == Boolean.TRUE);
+    }
+
+}

--- a/common/src/main/java/com/paypal/selion/SeLionConstants.java
+++ b/common/src/main/java/com/paypal/selion/SeLionConstants.java
@@ -86,4 +86,15 @@ public class SeLionConstants {
      * Selenium system property for defining the location of edge driver.
      */
     public static final String WEBDRIVER_EDGE_DRIVER_PROPERTY = "webdriver.edge.driver";
+
+    /**
+     * Selenium system property for defining the location of Gecko/marionette driver
+     */
+    public static final String WEBDRIVER_GECKO_DRIVER_PROPERTY = "webdriver.gecko.driver";
+
+    /**
+     * Platform specific executable name for gecko/marionette driver
+     */
+    public static final String GECKO_DRIVER = SystemUtils.IS_OS_WINDOWS ? "geckodriver.exe" : "geckodriver";
+
 }

--- a/server/src/main/java/com/paypal/selion/grid/FileDownloader.java
+++ b/server/src/main/java/com/paypal/selion/grid/FileDownloader.java
@@ -49,7 +49,7 @@ final class FileDownloader {
     private static List<String> files = new ArrayList<String>();
     private static long lastModifiedTime;
     private static final List<String> SUPPORTED_TYPES = Arrays.asList(ArchiveStreamFactory.ZIP, ArchiveStreamFactory.TAR,
-            ArchiveStreamFactory.JAR, "bz2", "msi");
+            ArchiveStreamFactory.JAR, "bz2", "msi", "gz");
     private static final File DOWNLOAD_FILE = new File(SeLionGridConstants.DOWNLOAD_JSON_FILE);
 
     private FileDownloader() {

--- a/server/src/main/java/com/paypal/selion/grid/JarSpawner.java
+++ b/server/src/main/java/com/paypal/selion/grid/JarSpawner.java
@@ -123,7 +123,7 @@ public final class JarSpawner extends AbstractBaseProcessLauncher {
         // include everything a typical process launcher would add for a java process
         args.addAll(Arrays.asList(super.getJavaSystemPropertiesArguments()));
 
-        // include the WebDriver binary paths for Chromedriver, IEDriver, and PhantomJs
+        // include the WebDriver binary paths for Chromedriver, IEDriver, and PhantomJs, GeckoDriver
         args.addAll(Arrays.asList(getWebDriverBinarySystemPropertiesArguments()));
 
         LOGGER.exiting(args.toString());
@@ -152,6 +152,11 @@ public final class JarSpawner extends AbstractBaseProcessLauncher {
                 args.add("-D" + SeLionConstants.WEBDRIVER_PHANTOMJS_DRIVER_PROPERTY + "="
                         + SeLionConstants.SELION_HOME_DIR + SeLionConstants.PHANTOMJS_DRIVER);
             }
+            if (System.getProperty(SeLionConstants.WEBDRIVER_GECKO_DRIVER_PROPERTY) == null) {
+                args.add("-D" + SeLionConstants.WEBDRIVER_GECKO_DRIVER_PROPERTY + "="
+                        + SeLionConstants.SELION_HOME_DIR + SeLionConstants.GECKO_DRIVER);
+            }
+
         }
         LOGGER.exiting(args.toString());
         return args.toArray(new String[args.size()]);

--- a/server/src/main/resources/config/download.json
+++ b/server/src/main/resources/config/download.json
@@ -24,6 +24,22 @@
     }
   },
   {
+    "name": "geckodriver",
+    "roles": [ "node", "standalone" ],
+    "windows": {
+      "url": "https://github.com/mozilla/geckodriver/releases/download/v0.9.0/geckodriver-v0.9.0-win64.zip",
+      "checksum": "81c02ec7778e511cf393974e93de8f7988989039"
+    },
+    "linux": {
+      "url": "https://github.com/mozilla/geckodriver/releases/download/v0.9.0/geckodriver-v0.9.0-linux64.tar.gz",
+      "checksum": "918c5744ac2b013bd2a76560af2b8872a92850eb"
+    },
+    "mac": {
+      "url": "https://github.com/mozilla/geckodriver/releases/download/v0.9.0/geckodriver-v0.9.0-mac.tar.gz",
+      "checksum": "fe1373f5b8716939012199b67c60997318b3c201"
+    }
+  },
+  {
     "name": "phantomjs",
     "roles": [ "node", "standalone" ],
     "windows": {

--- a/server/src/test/java/com/paypal/selion/node/servlets/NodeServletsTest.java
+++ b/server/src/test/java/com/paypal/selion/node/servlets/NodeServletsTest.java
@@ -1,0 +1,60 @@
+/*-------------------------------------------------------------------------------------------------------------------*\
+|  Copyright (C) 2015 PayPal                                                                                          |
+|                                                                                                                     |
+|  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
+|  with the License.                                                                                                  |
+|                                                                                                                     |
+|  You may obtain a copy of the License at                                                                            |
+|                                                                                                                     |
+|       http://www.apache.org/licenses/LICENSE-2.0                                                                    |
+|                                                                                                                     |
+|  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed   |
+|  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for  |
+|  the specific language governing permissions and limitations under the License.                                     |
+\*-------------------------------------------------------------------------------------------------------------------*/
+
+package com.paypal.selion.node.servlets;
+
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+
+import java.security.Permission;
+
+public class NodeServletsTest {
+
+    @BeforeTest
+    public void setup() {
+        System.setSecurityManager(new NoExitSecurityManager());
+    }
+
+    @AfterTest
+    public void tearDown() {
+        System.setSecurityManager(null);
+    }
+
+    // Various node servlet tests will cause a System.exit() which fouls up our test execution.
+    // So install a security mgr to prevent actual exit from jvm.
+    protected static class ExitException extends SecurityException {
+        public final int status;
+        public ExitException(int status) {
+            super("There is no escape!");
+            this.status = status;
+        }
+    }
+
+    private static class NoExitSecurityManager extends SecurityManager {
+        @Override
+        public void checkPermission(Permission perm) {
+            // allow anything.
+        }
+        @Override
+        public void checkPermission(Permission perm, Object context) {
+            // allow anything.
+        }
+        @Override
+        public void checkExit(int status) {
+            super.checkExit(status);
+            throw new ExitException(status);
+        }
+    }
+}

--- a/server/src/test/resources/Default-Suite.xml
+++ b/server/src/test/resources/Default-Suite.xml
@@ -12,13 +12,13 @@
             <package name="com.paypal.selion.grid.*" />
             <package name="com.paypal.selion.proxy.*" />
             <package name="com.paypal.selion.resources.*" />
+            <package name="com.paypal.selion.node.*" />
         </packages>
     </test>
     <!-- set 2 is temporarily isolated due to issues co-existing with set 1 -->
     <!-- TODO fix the tests -->
     <test verbose="2" name="Default Tests - set 2" annotations="JDK">
         <packages>
-            <package name="com.paypal.selion.node.*" />
             <package name="com.paypal.selion.utils.*" />
         </packages>
     </test>


### PR DESCRIPTION
- Add iniitial support for using geckodriver with Firefox browser.
  (Selenium 2.53 does not work with Firefox 47.)
- Add a GeckoCapabilitiesBuilder for geckodriver.
- Add client config option for enabling Geckodriverand
  specifying Geckodriver path for local runs.
- Add marionette support in Grid server.
- Also added a test security manager to prevent System.exit()
  from some node servelet tests.
