### PR TITLE
Make Config ThreadSafe to allow overwriting non-global property from code.

### DIFF
--- a/client/src/main/java/com/paypal/selion/configuration/Config.java
+++ b/client/src/main/java/com/paypal/selion/configuration/Config.java
@@ -151,7 +151,7 @@ public final class Config {
             }
         }
 
-        ConfigManager.addConfig(context.getCurrentXmlTest().getName(), new LocalConfig(initialValues));
+        ConfigManager.addConfig(new LocalConfig(initialValues));
         SeLionLogger.getLogger().exiting();
     }
 
@@ -253,6 +253,8 @@ public final class Config {
         if (runLocally) {
             xmlConfig.setProperty(ConfigProperty.SELENIUM_HOST.getName(), "localhost");
         }
+
+        ConfigManager.addConfig(new LocalConfig(xmlConfig));
 
         SeLionLogger.getLogger().exiting();
     }

--- a/client/src/main/java/com/paypal/selion/configuration/LocalConfig.java
+++ b/client/src/main/java/com/paypal/selion/configuration/LocalConfig.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import net.jcip.annotations.ThreadSafe;
 
 import org.apache.commons.configuration.BaseConfiguration;
+import org.apache.commons.configuration.Configuration;
 import org.apache.commons.lang.StringUtils;
 
 import com.paypal.selion.configuration.Config.ConfigProperty;
@@ -95,6 +96,23 @@ public class LocalConfig {
                 }
                 baseConfig.setProperty(entry.getKey().getName(), entry.getValue());
             }
+        }
+    }
+
+    /**
+     * Constructs a new instance of this class from the specified initial values.
+     *
+     * @param initialValues
+     *            Map The initial MAP of ConfigProperty values used to create the local configuration.
+     */
+    public LocalConfig(Configuration config) {
+        this();
+
+        Iterator<String> it = config.getKeys();
+
+        while(it.hasNext()) {
+            String key = it.next();
+            baseConfig.setProperty(key, config.getProperty(key));
         }
     }
 

--- a/client/src/main/java/com/paypal/selion/internal/platform/grid/AbstractTestSession.java
+++ b/client/src/main/java/com/paypal/selion/internal/platform/grid/AbstractTestSession.java
@@ -267,7 +267,7 @@ public abstract class AbstractTestSession {
     }
 
     final String getLocalConfigProperty(ConfigProperty property) {
-        return ConfigManager.getConfig(this.xmlTestName).getConfigProperty(property);
+        return ConfigManager.getConfig().getConfigProperty(property);
     }
 
     /**

--- a/client/src/main/java/com/paypal/selion/internal/platform/grid/SeleniumGridListener.java
+++ b/client/src/main/java/com/paypal/selion/internal/platform/grid/SeleniumGridListener.java
@@ -434,7 +434,7 @@ public class SeleniumGridListener implements IInvokedMethodListener, ISuiteListe
         // does away with all the inherent setbacks that are associated with TestNG listeners orders.
         invokeInitializersBasedOnPriority(context);
 
-        ConfigManager.printConfiguration(testName);
+        ConfigManager.printConfiguration();
 
         ISuite suite = context.getSuite();
 

--- a/client/src/main/java/com/paypal/selion/internal/platform/grid/browsercapabilities/DriverFactoryHelper.java
+++ b/client/src/main/java/com/paypal/selion/internal/platform/grid/browsercapabilities/DriverFactoryHelper.java
@@ -73,7 +73,7 @@ final class DriverFactoryHelper {
             } else {
                 // Only for a firefox profile we are resorting to displaying the profile name alone
                 // instead of the actual string since it can pollute our logs.
-                capabilitiesAsString.append(ConfigManager.getConfig(Grid.getTestSession().getXmlTestName())
+                capabilitiesAsString.append(ConfigManager.getConfig()
                         .getConfigProperty(ConfigProperty.SELENIUM_FIREFOX_PROFILE));
             }
             capabilitiesAsString.append(",");

--- a/client/src/main/java/com/paypal/selion/platform/grid/Grid.java
+++ b/client/src/main/java/com/paypal/selion/platform/grid/Grid.java
@@ -79,7 +79,7 @@ public final class Grid {
      */
     public static long getExecutionTimeoutValue() {
         logger.entering();
-        String stringTimeOut = ConfigManager.getConfig(getTestSession().getXmlTestName()).getConfigProperty(
+        String stringTimeOut = ConfigManager.getConfig().getConfigProperty(
                 ConfigProperty.EXECUTION_TIMEOUT);
         long returnValue = Long.parseLong(stringTimeOut.trim());
         logger.exiting(returnValue);

--- a/client/src/main/java/com/paypal/selion/platform/grid/browsercapabilities/DefaultCapabilitiesBuilder.java
+++ b/client/src/main/java/com/paypal/selion/platform/grid/browsercapabilities/DefaultCapabilitiesBuilder.java
@@ -94,7 +94,6 @@ public abstract class DefaultCapabilitiesBuilder {
      * @return - A string that represents the configuration property.
      */
     public String getLocalConfigProperty(ConfigProperty configProperty) {
-        String testName = Grid.getTestSession().getXmlTestName();
-        return ConfigManager.getConfig(testName).getConfigProperty(configProperty);
+        return ConfigManager.getConfig().getConfigProperty(configProperty);
     }
 }

--- a/client/src/main/java/com/paypal/selion/platform/html/AbstractElement.java
+++ b/client/src/main/java/com/paypal/selion/platform/html/AbstractElement.java
@@ -360,7 +360,7 @@ public abstract class AbstractElement implements Clickable, Hoverable {
     }
 
     protected String getWaitTime() {
-        return ConfigManager.getConfig(Grid.getTestSession().getXmlTestName()).getConfigProperty(
+        return ConfigManager.getConfig().getConfigProperty(
                 ConfigProperty.EXECUTION_TIMEOUT);
     }
 

--- a/client/src/main/java/com/paypal/selion/testcomponents/AbstractPage.java
+++ b/client/src/main/java/com/paypal/selion/testcomponents/AbstractPage.java
@@ -92,8 +92,8 @@ public abstract class AbstractPage implements WebPage {
         mapQueue.add(new String[] { pageDomain, pageClassName });
         AbstractTestSession session = Grid.getTestSession();
 
-        if (session != null && StringUtils.isNotBlank(session.getXmlTestName())) {
-            LocalConfig lc = ConfigManager.getConfig(session.getXmlTestName());
+        if (session != null) {
+            LocalConfig lc = ConfigManager.getConfig();
             site = lc.getConfigProperty(ConfigProperty.SITE_LOCALE);
         }
     }

--- a/client/src/test/java/com/paypal/selion/configuration/ConfigManagerTest.java
+++ b/client/src/test/java/com/paypal/selion/configuration/ConfigManagerTest.java
@@ -35,13 +35,13 @@ public class ConfigManagerTest {
         assertNotNull(localConfig, "could not get the SeLion local config");
         // Set new values in local config
         localConfig.setConfigProperty(ConfigProperty.BROWSER, BrowserFlavors.OPERA.getBrowser());
-        ConfigManager.addConfig(TEST_CONFIG_NAME, localConfig);
+        ConfigManager.addConfig(localConfig);
     }
 
     @Test(groups = { "unit" }, dependsOnMethods = { "testAddConfig" })
     public void testGetConfig() {
         assertNotNull(localConfig, "Could not get the SeLion local config");
-        LocalConfig testConfig = ConfigManager.getConfig(TEST_CONFIG_NAME);
+        LocalConfig testConfig = ConfigManager.getConfig();
         assertNotNull(testConfig);
         String newBrowserValue = testConfig.getConfigProperty(ConfigProperty.BROWSER);
         assertTrue(newBrowserValue.equals(browserValue), "value from local config is not equal to the value set");
@@ -50,13 +50,13 @@ public class ConfigManagerTest {
 
     @Test(groups = { "unit" }, dependsOnMethods = { "testGetConfig", "testAddConfig" })
     public void testRemoveConfig() {
-        assertTrue(ConfigManager.removeConfig(TEST_CONFIG_NAME), "Remove config failed");
+        assertTrue(ConfigManager.removeConfig(), "Remove config failed");
     }
 
     @Test(groups = { "unit" }, dependsOnMethods = { "testAddConfig" })
     public void testGetConfigProperty(ITestContext ctx) {
         String name = ctx.getCurrentXmlTest().getName();
-        String browser = ConfigManager.getConfig(name).getConfigProperty(ConfigProperty.BROWSER);
+        String browser = ConfigManager.getConfig().getConfigProperty(ConfigProperty.BROWSER);
         assertNotNull(browser);
     }
 }

--- a/client/src/test/java/com/paypal/selion/configuration/ConfigParallelTest.java
+++ b/client/src/test/java/com/paypal/selion/configuration/ConfigParallelTest.java
@@ -1,0 +1,31 @@
+package com.paypal.selion.configuration;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class ConfigParallelTest {
+
+    @DataProvider(name = "threadSafe", parallel = true)
+    public Object[][] data() {
+        return new String[][] {
+                {"*firefox"},
+                {"*chrome"},
+                {"*firefox"},
+                {"*chrome"}
+        };
+    }
+
+    @BeforeMethod(groups = { "unit" })
+    public void before(Object... objects) {
+        if(objects.length > 0 && objects[0] != null) {
+            ConfigManager.getConfig().setConfigProperty(Config.ConfigProperty.BROWSER, (String) objects[0]);
+        }
+    }
+
+    @Test(groups = { "unit" }, dataProvider = "threadSafe")
+    public void testTheadSafeConfig(String browser) {
+        Assert.assertEquals(ConfigManager.getConfig().getConfigProperty(Config.ConfigProperty.BROWSER), browser);
+    }
+}

--- a/client/src/test/java/com/paypal/selion/configuration/LocalConfigTest.java
+++ b/client/src/test/java/com/paypal/selion/configuration/LocalConfigTest.java
@@ -44,7 +44,7 @@ public class LocalConfigTest {
         initLocalValues.put(ConfigProperty.SELENIUM_USERAGENT, localUserAgentValue);
         LocalConfig localConfig = new LocalConfig(initLocalValues);
         String testName = "test";
-        ConfigManager.addConfig(testName, localConfig);
+        ConfigManager.addConfig(localConfig);
         assertEquals(localConfig.getConfigProperty(ConfigProperty.SELENIUM_USERAGENT), localUserAgentValue,
                 "Hostname value not as expected");
         String userAgent = Config.getConfigProperty(ConfigProperty.SELENIUM_USERAGENT);
@@ -52,7 +52,7 @@ public class LocalConfigTest {
         assertTrue(!userAgent.equals(localUserAgentValue),
                 "hostname values in localConfig and selionConfig should not match");
         // cleanup
-        ConfigManager.removeConfig(testName);
+        ConfigManager.removeConfig();
     }
 
     @Test(groups = "unit")
@@ -70,14 +70,14 @@ public class LocalConfigTest {
 
     @Test(groups = { "parallelBrowserTest1" })
     public void testGetLocalConfigValues(ITestContext ctx) {
-        LocalConfig lc = ConfigManager.getConfig(ctx.getCurrentXmlTest().getName());
+        LocalConfig lc = ConfigManager.getConfig();
         Map<String, String> values = lc.getLocalConfigValues();
         assertTrue(values.get("browser").equals("*chrome"));
     }
 
     @Test(groups = { "parallelBrowserTest1" })
     public void testgetLocalConfigValues(ITestContext ctx) throws Exception {
-        LocalConfig lc = ConfigManager.getConfig(ctx.getCurrentXmlTest().getName());
+        LocalConfig lc = ConfigManager.getConfig();
         Map<String, String> localValues = lc.getLocalConfigValues();
         assertTrue(!localValues.isEmpty());
     }
@@ -85,22 +85,19 @@ public class LocalConfigTest {
     // Parallel=tests with different browsers. (See SeLionConfigTest-Parallel-Tests-Suite.xml)
     @Test(groups = "parallelBrowserTest1")
     public void testParallelLocalConfigChrome(ITestContext ctx) {
-        String name = ctx.getCurrentXmlTest().getName();
-        String default_browser = ConfigManager.getConfig(name).getConfigProperty(ConfigProperty.BROWSER);
+        String default_browser = ConfigManager.getConfig().getConfigProperty(ConfigProperty.BROWSER);
         assertEquals(default_browser, "*chrome", "Browser config value for this test is not chrome.");
     }
 
     @Test(groups = "parallelBrowserTest2")
     public void testParallelLocalConfigIE(ITestContext ctx) {
-        String name = ctx.getCurrentXmlTest().getName();
-        String default_browser = ConfigManager.getConfig(name).getConfigProperty(ConfigProperty.BROWSER);
+        String default_browser = ConfigManager.getConfig().getConfigProperty(ConfigProperty.BROWSER);
         assertEquals(default_browser, "*iexplore", "Browser config value for this test is not iexplore.");
     }
 
     @Test(groups = "parallelBrowserTest3")
     public void testParallelLocalConfigFireFox(ITestContext ctx) {
-        String name = ctx.getCurrentXmlTest().getName();
-        String default_browser = ConfigManager.getConfig(name).getConfigProperty(ConfigProperty.BROWSER);
+        String default_browser = ConfigManager.getConfig().getConfigProperty(ConfigProperty.BROWSER);
         assertEquals(default_browser, "*firefox", "Browser config value for this test is not firefox.");
     }
 

--- a/client/src/test/java/com/paypal/selion/platform/grid/GridTest.java
+++ b/client/src/test/java/com/paypal/selion/platform/grid/GridTest.java
@@ -37,7 +37,7 @@ public class GridTest {
     @WebTest
     @Test(groups = "functional")
     public void testGetNewTimeOut(ITestContext ctx) {
-        LocalConfig lc = ConfigManager.getConfig(ctx.getCurrentXmlTest().getName());
+        LocalConfig lc = ConfigManager.getConfig();
         lc.setConfigProperty(ConfigProperty.EXECUTION_TIMEOUT, "20000");
         assertEquals(Grid.getExecutionTimeoutValue(), 20000l, "Verify the timeout value is correctly retrieved");
     }

--- a/client/src/test/java/com/paypal/selion/platform/grid/SeleniumCapabilitiesTest.java
+++ b/client/src/test/java/com/paypal/selion/platform/grid/SeleniumCapabilitiesTest.java
@@ -38,7 +38,7 @@ public class SeleniumCapabilitiesTest {
     @WebTest()
     public void testDefaultBrowser1(ITestContext ctx) {
         String userAgent = (String) Grid.driver().executeScript("return navigator.userAgent", "");
-        String browser = ConfigManager.getConfig(ctx.getCurrentXmlTest().getName())
+        String browser = ConfigManager.getConfig()
                 .getConfigProperty(ConfigProperty.BROWSER).replace("*", "");
         assertTrue(userAgent.toLowerCase().contains(browser));
     }
@@ -47,7 +47,7 @@ public class SeleniumCapabilitiesTest {
     @WebTest(browser = "")
     public void testDefaultBrowser2(ITestContext ctx) {
         String userAgent = (String) Grid.driver().executeScript("return navigator.userAgent", "");
-        String browser = ConfigManager.getConfig(ctx.getCurrentXmlTest().getName())
+        String browser = ConfigManager.getConfig()
                 .getConfigProperty(ConfigProperty.BROWSER).replace("*", "");
         assertTrue(userAgent.toLowerCase().contains(browser));
     }

--- a/client/src/test/resources/suites/Full-Suite.xml
+++ b/client/src/test/resources/suites/Full-Suite.xml
@@ -14,6 +14,7 @@
         <suite-file path="SeLionConfig-Suite.xml"></suite-file>
         <suite-file path="SeLionConfig-Parallel-Tests-Suite.xml"></suite-file>
         <suite-file path="SeLionConfig-Parallel-Classes-Suite.xml"></suite-file>
+        <suite-file path="SeLionConfig-Parallel-Classes-LocalConfig-Suite.xml"></suite-file>
         <suite-file path="Firefox-Suite.xml"></suite-file>
         <suite-file path="Chrome-Suite.xml"></suite-file>
         <suite-file path="IE-Suite.xml"></suite-file>

--- a/client/src/test/resources/suites/SeLionConfig-Parallel-Classes-LocalConfig-Suite.xml
+++ b/client/src/test/resources/suites/SeLionConfig-Parallel-Classes-LocalConfig-Suite.xml
@@ -1,0 +1,18 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+<suite thread-count="100" verbose="1" name="SeLion Config Test Suite" skipfailedinvocationcounts="false" junit="false"
+       parallel="classes" data-provider-thread-count="50" annotations="JDK">
+    <listeners>
+        <listener class-name="com.paypal.selion.reports.runtime.DebugListener" />
+    </listeners>
+
+    <test verbose="2" name="Test1" annotations="JDK">
+        <groups>
+            <run>
+                <include name="unit" />
+            </run>
+        </groups>
+        <classes>
+            <class name="com.paypal.selion.configuration.ConfigParallelTest" />
+        </classes>
+    </test>
+</suite>


### PR DESCRIPTION
This is change gives a user the ability to overwrite certain properties from the code without it affecting other runs.

This is beneficial in the following situation:

``` java
//This would affect all the running test cases by overwriting the UserAgent to iPhone.
Config.setConfigProperty(ConfigProperty.SELENIUM_USERAGENT, "Mozilla/5.0 (iPhone; CPU iPhone OS 5_0 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A334 Safari/7534.48.3");

//Now we can use the following which only affects the test case that we are executing.
Config.setConfigPropertyThreadSafe(ConfigProperty.SELENIUM_USERAGENT, "Mozilla/5.0 (iPhone; CPU iPhone OS 5_0 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A334 Safari/7534.48.3");
```

Or in our situation where the amount of cases is so big that it is unmanageable to manage all in suite files with LocalConfig properties.

The change should be fully backwards compatible.
