### PR TITLE
Revert TestNG version back to 6.9.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <iosdriver.version>0.6.5</iosdriver.version>
         <selendroid.version>0.17.0</selendroid.version>
         <appium.version>4.1.2</appium.version>
-        <testng.version>6.9.12</testng.version>
+        <testng.version>6.9.10</testng.version>
         <snakeyaml.version>1.15</snakeyaml.version>
         <htmlunit.version>2.20</htmlunit.version>
         <project.bom.version>${project.version}</project.bom.version>
@@ -59,11 +59,6 @@
             <id>sonatype-nexus-snapshots</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </repository>
-        <repository>
-            <id>jcenter</id>
-            <name>bintray</name>
-            <url>http://jcenter.bintray.com</url>
-          </repository>
     </repositories>
 
     <distributionManagement>


### PR DESCRIPTION
- [X] By placing an `X` in the preceding checkbox, I verify that I am a PayPal employee or
  I have signed the [Contributor License Agreement](https://github.com/paypal/SeLion#contributing)

---

Revert TestNG version back to 6.9.10 due to fixes needed in SessionSharingand SoftAsserts.
