### PR TITLE
Fix #306: Custom elements in page containers

### DIFF
--- a/codegen/src/main/java/com/paypal/selion/elements/HtmlSeLionElementList.java
+++ b/codegen/src/main/java/com/paypal/selion/elements/HtmlSeLionElementList.java
@@ -65,9 +65,10 @@ public class HtmlSeLionElementList extends AbstractSeLionElementList {
      * @param element string of the qualified class
      */
     public static void registerElement(String element) {
-        List<HtmlSeLionElementList> temp = new ArrayList<HtmlSeLionElementList>(Arrays.asList(values));
+        List<HtmlSeLionElementList> temp = new ArrayList<>(Arrays.asList(values));
         
-        temp.add(0, new HtmlSeLionElementList(HtmlElementUtils.getPackage(element), HtmlElementUtils.getClass(element), true, false));
+        temp.add(0, new HtmlSeLionElementList(HtmlElementUtils.getPackage(element), HtmlElementUtils.getClass(element),
+                true, true));
         
         values = temp.toArray(new HtmlSeLionElementList[temp.size()]);
     }

--- a/codegen/src/main/java/com/paypal/selion/reader/AbstractYamlReader.java
+++ b/codegen/src/main/java/com/paypal/selion/reader/AbstractYamlReader.java
@@ -115,7 +115,7 @@ public abstract class AbstractYamlReader {
 
     protected List<String> parseKeysForContainer(String fileName, Map<String, HtmlContainerElement> allElements) {
 
-        List<String> elementKeys = new ArrayList<String>();
+        List<String> elementKeys = new ArrayList<>();
 
         for (Entry<String, HtmlContainerElement> element : allElements.entrySet()) {
             try {

--- a/pom.xml
+++ b/pom.xml
@@ -160,35 +160,6 @@
     <build>
         <pluginManagement>
             <plugins>
-                <!-- this plugin is a maven plugin designed to hold meta data to communicate with eclipse m2e plugin when 
-                    it processes a maven pom.xml. Without this, children of this pom file will get the warning 
-                    "maven-enforcer-plugin (goal enforce) is ignored by m2e" because there is no connector that tells 
-                    m2e how to integrate the maven plugin into eclipse. -->
-                <plugin>
-                    <groupId>org.eclipse.m2e</groupId>
-                    <artifactId>lifecycle-mapping</artifactId>
-                    <version>1.0.0</version>
-                    <configuration>
-                        <lifecycleMappingMetadata>
-                            <pluginExecutions>
-                                <pluginExecution>
-                                    <pluginExecutionFilter>
-                                        <groupId>org.apache.maven.plugins</groupId>
-                                        <artifactId>maven-enforcer-plugin</artifactId>
-                                        <versionRange>[1.0.0,)</versionRange>
-                                        <goals>
-                                            <goal>enforce</goal>
-                                        </goals>
-                                    </pluginExecutionFilter>
-                                    <action>
-                                        <ignore />
-                                    </action>
-                                </pluginExecution>
-                            </pluginExecutions>
-                        </lifecycleMappingMetadata>
-                    </configuration>
-                </plugin>
-
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
- [x] By placing an `X` in the preceding checkbox, I verify that I am a PayPal employee or
I have signed the [Contributor License Agreement](https://github.com/paypal/SeLion#contributing)

---

- Fix #306
- Support custom elements in page object containers
- Also unrelated change in parent POM to remove
  eclipse lifecycle mapping plugin.