### PR TITLE
support chrome-headless & firefox-headless

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ jdk:
 addons:
   sauce_connect: true
   chrome: stable
+  firefox: latest
 cache:
   directories:
     - $HOME/.m2
@@ -24,19 +25,15 @@ notifications:
     on_failure: always
     on_start: never
 env:
-  global:
-    - DISPLAY=:99.0
   matrix:
     - TARGET=phantom
     - TARGET=chrome
     - TARGET=firefox
 matrix:
   allow_failures:
-    - env: TARGET=chrome
     - env: TARGET=firefox
   fast_finish: true
 before_script:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sh -e /etc/init.d/xvfb start; sleep 3; fi
   - echo "MAVEN_OPTS='-Xmx1g -Xms256m'" > ~/.mavenrc
 script:
   - |
@@ -53,5 +50,5 @@ script:
       fi
   - |
       if [[ $TRAVIS_OS_NAME == 'linux' ]] && [[ $TARGET == *"firefox"* ]]; then
-        sh -e utilities/travis-run-firefox-tests.sh
+        USE_SAUCELABS=true sh -e utilities/travis-run-firefox-tests.sh
       fi

--- a/client/src/main/java/com/paypal/selion/configuration/Config.java
+++ b/client/src/main/java/com/paypal/selion/configuration/Config.java
@@ -1,5 +1,5 @@
 /*-------------------------------------------------------------------------------------------------------------------*\
-|  Copyright (C) 2014-2016 PayPal                                                                                     |
+|  Copyright (C) 2014-2017 PayPal                                                                                     |
 |                                                                                                                     |
 |  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
 |  with the License.                                                                                                  |
@@ -51,9 +51,9 @@ import com.paypal.selion.platform.html.support.events.ElementEventListener;
  *
  * <pre>
  * &lt;!-- If parameter is empty string or omitted, please see defaults --&gt;
- * 
+ *
  * &lt;!-- SELENIUM CONFIGURATION --&gt;
- * 
+ *
  * &lt;!-- optional, defaults to "" or localhost when runLocally is true (GLOBAL) --&gt;
  * &lt;parameter name="seleniumhost" value="" /&gt;
  * &lt;!-- optional, defaults to 4444 (GLOBAL) --&gt;
@@ -66,9 +66,9 @@ import com.paypal.selion.platform.html.support.events.ElementEventListener;
  * &lt;parameter name="autoScreenShot" value="true" /&gt;
  * &lt;!-- optional, used when runLocally is true, defaults to 'default' --&gt;
  * &lt;parameter name="profileName" value="SeleniumProfile" /&gt;
- * 
+ *
  * &lt;!-- SELION FILES LOCATION --&gt;
- * 
+ *
  * &lt;!-- optional, default to selionFiles (GLOBAL) --&gt;
  * &lt;parameter name="basedir" value=""  /&gt;
  * &lt;!-- optional, default to ${selionFiles.basedir}/selionLogs (GLOBAL) --&gt;
@@ -435,6 +435,7 @@ public final class Config {
          * The path to the PhantomJS executable on the local machine. This parameter is taken into consideration for
          * local runs involving the PhantomJS browser.
          */
+        @Deprecated
         SELENIUM_PHANTOMJS_PATH("phantomjsPath", "", true),
 
         /**
@@ -703,24 +704,28 @@ public final class Config {
          * The unit is milliseconds.<br>
          * Default is set to <b>1800000</b> milliseconds.
          */
+        @Deprecated
         MOBILE_DRIVER_SESSION_TIMEOUT("sessionTimeout", "1800000", false),
 
         /**
          * Selendroid Server port to use.<br>
          * Defaults to the value used by Selendroid (<b>8080</b>)
          */
+        @Deprecated
         SELENDROID_SERVER_PORT("selendroidServerPort", "8080", true),
 
         /**
          * Device Serial to use.<br>
          * Default is selected automatically by Selendroid
          */
+        @Deprecated
         SELENDROID_DEVICE_SERIAL("selendroidDeviceSerial", "", true),
 
         /**
          * Force Reinstall the Selendroid Server and AUT.<br>
          * Default is set to <b>false</b>
          */
+        @Deprecated
         SELENDROID_SERVER_FORCE_REINSTALL("selendroidServerForceReinstall", "false", true),
 
         /**
@@ -731,6 +736,7 @@ public final class Config {
          * The unit is milliseconds.<br>
          * Default is set to <b>300000</b> milliseconds.<br>
          */
+        @Deprecated
         SELENDROID_EMULATOR_START_TIMEOUT("timeoutEmulatorStart", "300000", false),
 
         /**
@@ -741,6 +747,7 @@ public final class Config {
          * The unit is milliseconds.<br>
          * Default is set to <b>20000</b> milliseconds.<br>
          */
+        @Deprecated
         SELENDROID_SERVER_START_TIMEOUT("serverStartTimeout", "20000", false),
 
         /**

--- a/client/src/main/java/com/paypal/selion/internal/platform/grid/BrowserFlavors.java
+++ b/client/src/main/java/com/paypal/selion/internal/platform/grid/BrowserFlavors.java
@@ -1,5 +1,5 @@
 /*-------------------------------------------------------------------------------------------------------------------*\
-|  Copyright (C) 2014-15 PayPal                                                                                       |
+|  Copyright (C) 2014-2017 PayPal                                                                                     |
 |                                                                                                                     |
 |  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
 |  with the License.                                                                                                  |
@@ -23,12 +23,15 @@ import java.util.List;
  */
 public enum BrowserFlavors {
     FIREFOX("*firefox"),
+    FIREFOX_HEADLESS("*firefox-headless"),
     INTERNET_EXPLORER("*iexplore"),
     MICROSOFT_EDGE("*microsoftedge"),
     HTMLUNIT("*htmlunit"),
     CHROME("*chrome"),
+    CHROME_HEADLESS("*chrome-headless"),
     SAFARI("*safari"),
     OPERA("*opera"),
+    @Deprecated
     PHANTOMJS("*phantomjs");
 
     private String browser;
@@ -39,7 +42,7 @@ public enum BrowserFlavors {
 
     /**
      * Returns the browser flavor as a string
-     * 
+     *
      * @return - A string that represents the browser flavor in question
      */
     public String getBrowser() {
@@ -49,7 +52,7 @@ public enum BrowserFlavors {
     /**
      * This method returns all the browser flavors that are supported by the SeLion framework as a String with each
      * value delimited by a comma.
-     * 
+     *
      * @return - A comma separated string that represents all supported browser flavors.
      */
     public static String getSupportedBrowsersAsCSV() {
@@ -91,7 +94,7 @@ public enum BrowserFlavors {
     public static BrowserFlavors[] getBrowsersWithoutAlertSupport() {
         return new BrowserFlavors[] { PHANTOMJS };
     }
-    
+
     /**
      * @param flavor - A object that represents a browser.
      * @return <code>true</code> if the given browser is a headless browser.

--- a/client/src/main/java/com/paypal/selion/internal/platform/grid/LocalIOSNode.java
+++ b/client/src/main/java/com/paypal/selion/internal/platform/grid/LocalIOSNode.java
@@ -1,5 +1,5 @@
 /*-------------------------------------------------------------------------------------------------------------------*\
-|  Copyright (C) 2014-2016 PayPal                                                                                     |
+|  Copyright (C) 2014-2017 PayPal                                                                                     |
 |                                                                                                                     |
 |  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
 |  with the License.                                                                                                  |
@@ -33,6 +33,7 @@ import com.paypal.test.utilities.logging.SimpleLogger;
  * A singleton that is responsible for encapsulating all the logic w.r.t starting/shutting down a local ios driver node.
  */
 @Beta
+@Deprecated
 final class LocalIOSNode extends AbstractBaseLocalServerComponent {
     private static final SimpleLogger LOGGER = SeLionLogger.getLogger();
     private static volatile LocalIOSNode instance;
@@ -121,7 +122,7 @@ final class LocalIOSNode extends AbstractBaseLocalServerComponent {
      * Checks the presence of ios-driver specific parameters provided by the user and validates them.
      * IllegalArgumentException is thrown if the parameter is either insufficient or irrelevant. Throws a
      * NullPointerException if the received configProperty is null.
-     * 
+     *
      * @param configProperty
      *            a SeLion {@link ConfigProperty} to validate
      */

--- a/client/src/main/java/com/paypal/selion/internal/platform/grid/LocalSelendroidNode.java
+++ b/client/src/main/java/com/paypal/selion/internal/platform/grid/LocalSelendroidNode.java
@@ -1,5 +1,5 @@
 /*-------------------------------------------------------------------------------------------------------------------*\
-|  Copyright (C) 2014-2015 PayPal                                                                                     |
+|  Copyright (C) 2014-2017 PayPal                                                                                     |
 |                                                                                                                     |
 |  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
 |  with the License.                                                                                                  |
@@ -33,6 +33,7 @@ import com.paypal.test.utilities.logging.SimpleLogger;
  * A singleton that is responsible for encapsulating all the logic w.r.t starting/shutting down a local selendroid node.
  */
 @Beta
+@Deprecated
 final class LocalSelendroidNode extends AbstractBaseLocalServerComponent {
     private static final SimpleLogger LOGGER = SeLionLogger.getLogger();
     private static volatile LocalSelendroidNode instance;
@@ -142,7 +143,7 @@ final class LocalSelendroidNode extends AbstractBaseLocalServerComponent {
      * Checks the presence of selendroid specific parameters provided by the user and validates them.
      * IllegalArgumentException is thrown if the parameter is either insufficient or irrelevant. Throws a
      * NullPointerException if the received configProperty is null.
-     * 
+     *
      * @param configProperty a SeLion {@link ConfigProperty} to validate
      */
     private void checkAndValidateParameters(ConfigProperty configProperty) {

--- a/client/src/main/java/com/paypal/selion/internal/platform/grid/MobileNodeType.java
+++ b/client/src/main/java/com/paypal/selion/internal/platform/grid/MobileNodeType.java
@@ -17,11 +17,11 @@ package com.paypal.selion.internal.platform.grid;
 
 /**
  * Enum to represent the valid mobile node types.
- * 
+ *
  */
 public enum MobileNodeType {
 
-    APPIUM("appium"), IOS_DRIVER("ios-driver"), SELENDROID("selendroid");
+    APPIUM("appium"), @Deprecated IOS_DRIVER("ios-driver"), @Deprecated SELENDROID("selendroid");
 
     private String mobileNodeType;
 
@@ -36,7 +36,7 @@ public enum MobileNodeType {
     /**
      * This method returns all the mobile node typesthat are supported by the SeLion framework as a String with each
      * value delimited by a comma.
-     * 
+     *
      * @return - A comma separated string that represents all supported mobile node types.
      */
     public static String getSupportedMobileNodesAsCSV() {

--- a/client/src/main/java/com/paypal/selion/internal/platform/grid/browsercapabilities/HeadlessChromeCapabilitiesBuilder.java
+++ b/client/src/main/java/com/paypal/selion/internal/platform/grid/browsercapabilities/HeadlessChromeCapabilitiesBuilder.java
@@ -1,5 +1,5 @@
 /*-------------------------------------------------------------------------------------------------------------------*\
-|  Copyright (C) 2015 PayPal                                                                                          |
+|  Copyright (C) 2017 PayPal                                                                                          |
 |                                                                                                                     |
 |  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
 |  with the License.                                                                                                  |
@@ -15,31 +15,25 @@
 
 package com.paypal.selion.internal.platform.grid.browsercapabilities;
 
-import static org.testng.Assert.assertTrue;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.remote.DesiredCapabilities;
 
 import java.util.List;
+import java.util.Map;
 
-import org.openqa.selenium.remote.DesiredCapabilities;
-import org.testng.annotations.Test;
+public class HeadlessChromeCapabilitiesBuilder extends ChromeCapabilitiesBuilder {
+    @Override
+    public DesiredCapabilities getCapabilities(DesiredCapabilities capabilities) {
+        capabilities = super.getCapabilities(capabilities);
+        Map<String, List<String>> existing =
+            (Map<String, List<String>>) capabilities.asMap().get(ChromeOptions.CAPABILITY);
 
-import com.paypal.selion.configuration.Config;
-import com.paypal.selion.configuration.Config.ConfigProperty;
-
-public class AdditionalSauceCapabilitiesBuilderTest {
-    private static final String SAUCE_CONFIG_FILE = "sauceConfig.json";
-
-    @Test
-    public void test() {
-        Config.setConfigProperty(ConfigProperty.SELENIUM_SAUCELAB_GRID_CONFIG_FILE, SAUCE_CONFIG_FILE);
-        Config.setConfigProperty(ConfigProperty.SELENIUM_USE_SAUCELAB_GRID, "true");
-        AdditionalSauceCapabilitiesBuilder builder = new AdditionalSauceCapabilitiesBuilder();
-        DesiredCapabilities capabilities = builder.getCapabilities(new DesiredCapabilities());
-
-        assertTrue(capabilities.getCapability("tunnel-identifier").equals(""));
-        assertTrue(capabilities.getCapability("tags") instanceof List<?>);
-        assertTrue(capabilities.getCapability("selenium-version") != null);
-        assertTrue(capabilities.getCapability("username") != null);
-        assertTrue(capabilities.getCapability("accessKey") != null);
-        assertTrue(capabilities.getCapability("parent-tunnel") != null);
+        ChromeOptions updated = new ChromeOptions();
+        if (existing != null) {
+            updated.addArguments(existing.get("args"));
+        }
+        updated.setHeadless(true);
+        capabilities.setCapability(ChromeOptions.CAPABILITY, updated);
+        return capabilities;
     }
 }

--- a/client/src/main/java/com/paypal/selion/internal/platform/grid/browsercapabilities/HeadlessFirefoxCapabilitiesBuilder.java
+++ b/client/src/main/java/com/paypal/selion/internal/platform/grid/browsercapabilities/HeadlessFirefoxCapabilitiesBuilder.java
@@ -1,5 +1,5 @@
 /*-------------------------------------------------------------------------------------------------------------------*\
-|  Copyright (C) 2015 PayPal                                                                                          |
+|  Copyright (C) 2017 PayPal                                                                                          |
 |                                                                                                                     |
 |  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
 |  with the License.                                                                                                  |
@@ -15,31 +15,25 @@
 
 package com.paypal.selion.internal.platform.grid.browsercapabilities;
 
-import static org.testng.Assert.assertTrue;
+import org.openqa.selenium.firefox.FirefoxOptions;
+import org.openqa.selenium.remote.DesiredCapabilities;
 
 import java.util.List;
+import java.util.Map;
 
-import org.openqa.selenium.remote.DesiredCapabilities;
-import org.testng.annotations.Test;
+public class HeadlessFirefoxCapabilitiesBuilder extends FireFoxCapabilitiesBuilder {
+    @Override
+    public DesiredCapabilities getCapabilities(DesiredCapabilities capabilities) {
+        capabilities = super.getCapabilities(capabilities);
+        Map<String, List<String>> existing =
+            (Map<String, List<String>>) capabilities.asMap().get(FirefoxOptions.FIREFOX_OPTIONS);
 
-import com.paypal.selion.configuration.Config;
-import com.paypal.selion.configuration.Config.ConfigProperty;
-
-public class AdditionalSauceCapabilitiesBuilderTest {
-    private static final String SAUCE_CONFIG_FILE = "sauceConfig.json";
-
-    @Test
-    public void test() {
-        Config.setConfigProperty(ConfigProperty.SELENIUM_SAUCELAB_GRID_CONFIG_FILE, SAUCE_CONFIG_FILE);
-        Config.setConfigProperty(ConfigProperty.SELENIUM_USE_SAUCELAB_GRID, "true");
-        AdditionalSauceCapabilitiesBuilder builder = new AdditionalSauceCapabilitiesBuilder();
-        DesiredCapabilities capabilities = builder.getCapabilities(new DesiredCapabilities());
-
-        assertTrue(capabilities.getCapability("tunnel-identifier").equals(""));
-        assertTrue(capabilities.getCapability("tags") instanceof List<?>);
-        assertTrue(capabilities.getCapability("selenium-version") != null);
-        assertTrue(capabilities.getCapability("username") != null);
-        assertTrue(capabilities.getCapability("accessKey") != null);
-        assertTrue(capabilities.getCapability("parent-tunnel") != null);
+        FirefoxOptions updated = new FirefoxOptions();
+        if (existing != null) {
+            updated.addArguments(existing.get("args"));
+        }
+        updated.setHeadless(true);
+        capabilities.setCapability(FirefoxOptions.FIREFOX_OPTIONS, updated);
+        return capabilities;
     }
 }

--- a/client/src/main/java/com/paypal/selion/internal/platform/grid/browsercapabilities/PhantomJSCapabilitiesBuilder.java
+++ b/client/src/main/java/com/paypal/selion/internal/platform/grid/browsercapabilities/PhantomJSCapabilitiesBuilder.java
@@ -1,5 +1,5 @@
 /*-------------------------------------------------------------------------------------------------------------------*\
-|  Copyright (C) 2014-15 PayPal                                                                                       |
+|  Copyright (C) 2014-2017 PayPal                                                                                     |
 |                                                                                                                     |
 |  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
 |  with the License.                                                                                                  |
@@ -23,6 +23,7 @@ import com.paypal.selion.configuration.Config;
 import com.paypal.selion.configuration.Config.ConfigProperty;
 import com.paypal.selion.platform.grid.browsercapabilities.DefaultCapabilitiesBuilder;
 
+@Deprecated
 class PhantomJSCapabilitiesBuilder extends DefaultCapabilitiesBuilder {
 
     @Override

--- a/client/src/main/java/com/paypal/selion/internal/platform/grid/browsercapabilities/WebDriverFactory.java
+++ b/client/src/main/java/com/paypal/selion/internal/platform/grid/browsercapabilities/WebDriverFactory.java
@@ -1,5 +1,5 @@
 /*-------------------------------------------------------------------------------------------------------------------*\
-|  Copyright (C) 2015-2016 PayPal                                                                                          |
+|  Copyright (C) 2015-2017 PayPal                                                                                     |
 |                                                                                                                     |
 |  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
 |  with the License.                                                                                                  |
@@ -35,7 +35,7 @@ import com.paypal.test.utilities.logging.SimpleLogger;
 /**
  * This factory class is responsible for providing the framework with a {@link RemoteWebDriver} instance based on the
  * browser type.
- * 
+ *
  */
 public final class WebDriverFactory {
 
@@ -58,8 +58,14 @@ public final class WebDriverFactory {
         case FIREFOX:
             capability = new FireFoxCapabilitiesBuilder().createCapabilities();
             break;
+        case FIREFOX_HEADLESS:
+            capability = new HeadlessFirefoxCapabilitiesBuilder().createCapabilities();
+            break;
         case CHROME:
             capability = new ChromeCapabilitiesBuilder().createCapabilities();
+            break;
+        case CHROME_HEADLESS:
+            capability = new HeadlessChromeCapabilitiesBuilder().createCapabilities();
             break;
         case INTERNET_EXPLORER:
             capability = new IECapabilitiesBuilder().createCapabilities();

--- a/client/src/test/java/com/paypal/selion/platform/grid/WebTestTest.java
+++ b/client/src/test/java/com/paypal/selion/platform/grid/WebTestTest.java
@@ -30,7 +30,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import com.paypal.selion.annotations.WebTest;
-import com.paypal.selion.platform.grid.Grid;
 import com.paypal.selion.platform.grid.browsercapabilities.DefaultCapabilitiesBuilder;
 import com.paypal.selion.reports.runtime.SeLionReporter;
 
@@ -60,7 +59,7 @@ public class WebTestTest {
      **/
     @Test(groups = { "functional" }, threadPoolSize = 2, invocationCount = 2, timeOut = 10000)
     @WebTest
-    public void testUnamedSessionMultipleThreadsAndInvocations() {
+    public void testUnnamedSessionMultipleThreadsAndInvocations() {
         SeLionReporter.log("Browser start page", true, true);
     }
 
@@ -101,7 +100,7 @@ public class WebTestTest {
         caps.merge(new ChromeOptionsOverrideCapabilities().createCapabilities());
         assertEquals(caps.getCapability(CapabilityType.BROWSER_NAME), "chrome");
 
-        Map<String, List<String>> chromeOptions = (Map<String, List<String>>) 
+        Map<String, List<String>> chromeOptions = (Map<String, List<String>>)
                 Grid.getWebTestSession().getAdditionalCapabilities().getCapability(ChromeOptions.CAPABILITY);
         List<String> args = (List<String>) chromeOptions.get("args");
         assertEquals(args.size(), 1);

--- a/client/src/test/resources/suites/Chrome-Suite.xml
+++ b/client/src/test/resources/suites/Chrome-Suite.xml
@@ -2,7 +2,7 @@
 <suite thread-count="5" verbose="1" name="Chrome Unit Test Suite" skipfailedinvocationcounts="false" junit="false"
     parallel="methods" data-provider-thread-count="10" annotations="JDK">
 
-    <parameter name="browser" value="*chrome " />
+    <parameter name="browser" value="*chrome" />
 
     <test verbose="2" name="Chrome-Test" annotations="JDK">
         <groups>

--- a/client/src/test/resources/suites/Chrome-Suite.xml
+++ b/client/src/test/resources/suites/Chrome-Suite.xml
@@ -2,7 +2,7 @@
 <suite thread-count="5" verbose="1" name="Chrome Unit Test Suite" skipfailedinvocationcounts="false" junit="false"
     parallel="methods" data-provider-thread-count="10" annotations="JDK">
 
-    <parameter name="browser" value="*chrome" />
+    <parameter name="browser" value="*chrome " />
 
     <test verbose="2" name="Chrome-Test" annotations="JDK">
         <groups>

--- a/utilities/travis-run-chrome-tests.sh
+++ b/utilities/travis-run-chrome-tests.sh
@@ -10,8 +10,11 @@ if [ -n "${SAUCE_USERNAME}" ]; then
   echo { \"sauceUserName\": \"${SAUCE_USERNAME}\", \"sauceApiKey\": \"${SAUCE_ACCESS_KEY}\", \"tunnel-identifier\": \"__string__${TRAVIS_JOB_NUMBER}\", \"build\": \"${TRAVIS_BUILD_NUMBER}\", \"idle-timeout\": 120, \"tags\": [\"commit ${TRAVIS_COMMIT}\", \"branch ${TRAVIS_BRANCH}\", \"pull request ${TRAVIS_PULL_REQUEST}\"] } > client/src/test/resources/sauceConfig.json
 fi
 
-mvn test -pl client -DsuiteXmlFile=Chrome-Suite.xml -DSELION_BROWSER=chrome-headless \
-  -DSELION_SELENIUM_RUN_LOCALLY=true -DSELION_DOWNLOAD_DEPENDENCIES=true \
-  -DSELION_SELENIUM_CUSTOM_CAPABILITIES_PROVIDER=com.paypal.selion.TravisCICapabilityBuilder \
-  -DBROWSER_PATH=`which google-chrome` -B -V
-exit $?
+if [ "$USE_SAUCELABS" = true ]; then
+  mvn test -pl client -B -V -DsuiteXmlFile=Chrome-Suite.xml -DSELION_BROWSER=chrome-headless && exit $?
+else
+  mvn test -pl client -B -V -DsuiteXmlFile=Chrome-Suite.xml -DSELION_BROWSER=chrome-headless \
+    -DSELION_SELENIUM_RUN_LOCALLY=true -DSELION_DOWNLOAD_DEPENDENCIES=true \
+    -DSELION_SELENIUM_CUSTOM_CAPABILITIES_PROVIDER=com.paypal.selion.TravisCICapabilityBuilder \
+    -DBROWSER_PATH=`which google-chrome` && exit $?
+fi

--- a/utilities/travis-run-chrome-tests.sh
+++ b/utilities/travis-run-chrome-tests.sh
@@ -10,7 +10,7 @@ if [ -n "${SAUCE_USERNAME}" ]; then
   echo { \"sauceUserName\": \"${SAUCE_USERNAME}\", \"sauceApiKey\": \"${SAUCE_ACCESS_KEY}\", \"tunnel-identifier\": \"__string__${TRAVIS_JOB_NUMBER}\", \"build\": \"${TRAVIS_BUILD_NUMBER}\", \"idle-timeout\": 120, \"tags\": [\"commit ${TRAVIS_COMMIT}\", \"branch ${TRAVIS_BRANCH}\", \"pull request ${TRAVIS_PULL_REQUEST}\"] } > client/src/test/resources/sauceConfig.json
 fi
 
-mvn test -pl client -DsuiteXmlFile=Chrome-Suite.xml \
+mvn test -pl client -DsuiteXmlFile=Chrome-Suite.xml -DSELION_BROWSER=chrome-headless \
   -DSELION_SELENIUM_RUN_LOCALLY=true -DSELION_DOWNLOAD_DEPENDENCIES=true \
   -DSELION_SELENIUM_CUSTOM_CAPABILITIES_PROVIDER=com.paypal.selion.TravisCICapabilityBuilder \
   -DBROWSER_PATH=`which google-chrome` -B -V

--- a/utilities/travis-run-firefox-tests.sh
+++ b/utilities/travis-run-firefox-tests.sh
@@ -10,24 +10,9 @@ if [ -n "${SAUCE_USERNAME}" ]; then
   echo { \"sauceUserName\": \"${SAUCE_USERNAME}\", \"sauceApiKey\": \"${SAUCE_ACCESS_KEY}\", \"tunnel-identifier\": \"__string__${TRAVIS_JOB_NUMBER}\", \"build\": \"${TRAVIS_BUILD_NUMBER}\", \"idle-timeout\": 120, \"tags\": [\"commit ${TRAVIS_COMMIT}\", \"branch ${TRAVIS_BRANCH}\", \"pull request ${TRAVIS_PULL_REQUEST}\"] } > client/src/test/resources/sauceConfig.json
 fi
 
-# Remove any existing firefox data
-if [ "${TRAVIS}" = true ]; then
-  rm -rf ${HOME}/.mozilla
+if [ "$TRAVIS_REPO_SLUG" = "paypal/SeLion" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$USE_SAUCELABS" = true ]; then
+  mvn test -pl client -B -V -DsuiteXmlFile=Firefox-Suite.xml -DSELION_BROWSER=firefox-headless && exit $?
+else
+  mvn test -pl client -B -V -DsuiteXmlFile=Firefox-Suite.xml -DSELION_BROWSER=firefox-headless \
+    -DSELION_SELENIUM_RUN_LOCALLY=true -DSELION_DOWNLOAD_DEPENDENCIES=true && exit $?
 fi
-
-mkdir -p target
-cd target
-if [ ! -f "./firefox/firefox" ]
-then
-  export FIREFOX_VERSION=57.0
-  export FIREFOX_URL=http://download.cdn.mozilla.net/pub/firefox/releases/${FIREFOX_VERSION}/linux-x86_64/en-US/firefox-${FIREFOX_VERSION}.tar.bz2
-  wget -O firefox-${FIREFOX_VERSION}.tar.bz2 ${FIREFOX_URL}
-  # and install downloaded firefox
-  tar -xjf firefox-${FIREFOX_VERSION}.tar.bz2
-fi
-cd ..
-
-export PATH=${PWD}/target/firefox:${PATH}
-mvn test -pl client -B -V -DsuiteXmlFile=Firefox-Suite.xml -DSELION_BROWSER=firefox-headless \
-  -DSELION_SELENIUM_RUN_LOCALLY=true -DSELION_DOWNLOAD_DEPENDENCIES=true -B -V
-exit $?

--- a/utilities/travis-run-firefox-tests.sh
+++ b/utilities/travis-run-firefox-tests.sh
@@ -19,7 +19,7 @@ mkdir -p target
 cd target
 if [ ! -f "./firefox/firefox" ]
 then
-  export FIREFOX_VERSION=55.0
+  export FIREFOX_VERSION=57.0
   export FIREFOX_URL=http://download.cdn.mozilla.net/pub/firefox/releases/${FIREFOX_VERSION}/linux-x86_64/en-US/firefox-${FIREFOX_VERSION}.tar.bz2
   wget -O firefox-${FIREFOX_VERSION}.tar.bz2 ${FIREFOX_URL}
   # and install downloaded firefox
@@ -28,6 +28,6 @@ fi
 cd ..
 
 export PATH=${PWD}/target/firefox:${PATH}
-mvn test -pl client -B -V -DsuiteXmlFile=Firefox-Suite.xml \
+mvn test -pl client -B -V -DsuiteXmlFile=Firefox-Suite.xml -DSELION_BROWSER=firefox-headless \
   -DSELION_SELENIUM_RUN_LOCALLY=true -DSELION_DOWNLOAD_DEPENDENCIES=true -B -V
 exit $?


### PR DESCRIPTION
- [X] By placing an `X` in the preceding checkbox, I verify that I am a PayPal employee or
I have signed the [Contributor License Agreement](https://github.com/paypal/SeLion#contributing)

---

- support chrome-headless & firefox-headless
- deprecate phantomjs, selendroid, and ios-driver
- update travis build to use latest firefox for repo clones and sauce labs for parent repo
- update travis build to use chrome-headless and firefox-headless
- update travis build -- chrome tests are no longer allowed to fail