### PR TITLE
Added Protocol-Capability

### DIFF
--- a/client/src/main/java/com/paypal/selion/configuration/Config.java
+++ b/client/src/main/java/com/paypal/selion/configuration/Config.java
@@ -388,6 +388,13 @@ public final class Config {
          * Automatically take screen shots.<br>
          */
         AUTO_SCREEN_SHOT("autoScreenShot", "true", true),
+        
+        /**
+         * Protocol might be http or https. Used when
+         * {@link ConfigProperty#SELENIUM_RUN_LOCALLY} is <b>false</b>.<br>
+         * Default is set to <b>"http"</b>
+         */
+        SELENIUM_PROTOCOL("protocol", "http", true),
 
         /**
          * Selenium host might be localhost or another location where a Selenium server is running. Used when

--- a/client/src/main/java/com/paypal/selion/internal/platform/grid/browsercapabilities/DriverFactoryHelper.java
+++ b/client/src/main/java/com/paypal/selion/internal/platform/grid/browsercapabilities/DriverFactoryHelper.java
@@ -151,6 +151,7 @@ final class DriverFactoryHelper {
 
         URL url = null;
         String hostToRun = Config.getConfigProperty(ConfigProperty.SELENIUM_HOST);
+        String protocol = Config.getConfigProperty(ConfigProperty.SELENIUM_PROTOCOL);
 
         boolean runLocally = Boolean.parseBoolean(Config.getConfigProperty(ConfigProperty.SELENIUM_RUN_LOCALLY));
         String port = Config.getConfigProperty(ConfigProperty.SELENIUM_PORT);
@@ -165,7 +166,7 @@ final class DriverFactoryHelper {
                         + "via the TestNG suite file parameter : <parameter name=\"seleniumhost\" value=\"\" />";
                 throw new IllegalStateException(errMsg);
             }
-            url = new URL("http://" + hostToRun + ":" + port + "/wd/hub");
+            url = new URL(protocol + "://" + hostToRun + ":" + port + "/wd/hub");
         } catch (MalformedURLException e) {
             logger.log(Level.SEVERE, e.getMessage(), e);
         }

--- a/client/src/test/java/com/paypal/selion/configuration/ProtocolConfigTest.java
+++ b/client/src/test/java/com/paypal/selion/configuration/ProtocolConfigTest.java
@@ -1,0 +1,60 @@
+/*-------------------------------------------------------------------------------------------------------------------*\
+|  Copyright (C) 2014 PayPal                                                                                          |
+|                                                                                                                     |
+|  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
+|  with the License.                                                                                                  |
+|                                                                                                                     |
+|  You may obtain a copy of the License at                                                                            |
+|                                                                                                                     |
+|       http://www.apache.org/licenses/LICENSE-2.0                                                                    |
+|                                                                                                                     |
+|  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed   |
+|  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for  |
+|  the specific language governing permissions and limitations under the License.                                     |
+\*-------------------------------------------------------------------------------------------------------------------*/
+
+package com.paypal.selion.configuration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.testng.Assert;
+import org.testng.ITestContext;
+import org.testng.annotations.Test;
+
+import com.paypal.selion.configuration.Config.ConfigProperty;
+
+// Test requires execution with SeLionProtocolConfig-Suite.xml
+public class ProtocolConfigTest {
+	
+    @Test(groups = { "protocol" }, priority = 1)
+    public void testGetProtocalProperty() {
+        Assert.assertNotNull(Config.getConfigProperty(ConfigProperty.SELENIUM_PROTOCOL), "Get config property should not be null");
+    }
+
+    @Test(groups = { "protocol" }, priority = 2)
+    public void testInitProtocalConfig(ITestContext context) {
+        Config.initConfig(context);
+        Assert.assertNotNull(Config.getConfigProperty(ConfigProperty.SELENIUM_PROTOCOL), "Config should not be null");
+    }
+
+    @Test(groups = { "protocol" }, priority = 3)
+    public void testInitProtocalConfig_Negativ() {
+    	Assert.assertFalse(Config.getConfigProperty(ConfigProperty.SELENIUM_PROTOCOL).contentEquals("http"),
+    			"Negativ-TC: PROTOCOL should match the suite-file. (https) is set in suite file -> not (http)");
+    	
+    }
+
+    @Test(groups = { "protocol" }, priority = 4)
+    public void testInitProtocalConfig_ChangeOption() {
+    	Assert.assertEquals(Config.getConfigProperty(ConfigProperty.SELENIUM_PROTOCOL), "https",
+                "PROTOCOL should be (https)");
+        Map<ConfigProperty, String> initValues = new HashMap<ConfigProperty, String>();
+        initValues.put(ConfigProperty.SELENIUM_PROTOCOL, "http");
+        Config.initConfig(initValues);
+        Assert.assertEquals(Config.getConfigProperty(ConfigProperty.SELENIUM_PROTOCOL), "http",
+                "PROTOCOL should be (http)");
+    }
+    
+    
+}

--- a/client/src/test/java/com/paypal/selion/configuration/ProtocolConfigTest.java
+++ b/client/src/test/java/com/paypal/selion/configuration/ProtocolConfigTest.java
@@ -39,14 +39,14 @@ public class ProtocolConfigTest {
     }
 
     @Test(groups = { "protocol" }, priority = 3)
-    public void testInitProtocalConfig_Negativ() {
+    public void testInitProtocalConfigNegativ() {
     	Assert.assertFalse(Config.getConfigProperty(ConfigProperty.SELENIUM_PROTOCOL).contentEquals("http"),
     			"Negativ-TC: PROTOCOL should match the suite-file. (https) is set in suite file -> not (http)");
     	
     }
 
     @Test(groups = { "protocol" }, priority = 4)
-    public void testInitProtocalConfig_ChangeOption() {
+    public void testInitProtocalConfigChangeOption() {
     	Assert.assertEquals(Config.getConfigProperty(ConfigProperty.SELENIUM_PROTOCOL), "https",
                 "PROTOCOL should be (https)");
         Map<ConfigProperty, String> initValues = new HashMap<ConfigProperty, String>();

--- a/client/src/test/java/com/paypal/selion/configuration/ProtocolConfigTest.java
+++ b/client/src/test/java/com/paypal/selion/configuration/ProtocolConfigTest.java
@@ -1,5 +1,5 @@
 /*-------------------------------------------------------------------------------------------------------------------*\
-|  Copyright (C) 2014 PayPal                                                                                          |
+|  Copyright (C) 2018 PayPal                                                                                          |
 |                                                                                                                     |
 |  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
 |  with the License.                                                                                                  |
@@ -39,9 +39,9 @@ public class ProtocolConfigTest {
     }
 
     @Test(groups = { "protocol" }, priority = 3)
-    public void testInitProtocalConfigNegativ() {
+    public void testInitProtocalConfigNegative() {
     	Assert.assertFalse(Config.getConfigProperty(ConfigProperty.SELENIUM_PROTOCOL).contentEquals("http"),
-    			"Negativ-TC: PROTOCOL should match the suite-file. (https) is set in suite file -> not (http)");
+    			"Negative-TC: PROTOCOL should match the suite-file. (https) is set in suite file -> not (http)");
     	
     }
 

--- a/client/src/test/resources/suites/SeLionProtocolConfig-Suite.xml
+++ b/client/src/test/resources/suites/SeLionProtocolConfig-Suite.xml
@@ -1,0 +1,23 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+<suite thread-count="100" verbose="1" name="SeLion Protocol Config Test Suite" skipfailedinvocationcounts="false" junit="false"
+    parallel="false" data-provider-thread-count="50" annotations="JDK">
+    
+    <parameter name="protocol" value="https" />
+    
+    <listeners>
+    	<listener class-name="com.paypal.selion.reports.runtime.DebugListener" />
+    </listeners>
+    
+  	
+    <test verbose="2" name="Test1" annotations="JDK">
+        <groups>
+            <run>
+                <include name="protocol" />
+            </run>
+        </groups>
+        <classes>
+            <class name="com.paypal.selion.configuration.ProtocolConfigTest" />
+        </classes>
+    </test>
+</suite>
+

--- a/server/src/main/resources/config/download.json
+++ b/server/src/main/resources/config/download.json
@@ -11,16 +11,16 @@
     "name": "chromedriver",
     "roles": [ "node", "standalone" ],
     "windows": {
-      "url": "https://chromedriver.storage.googleapis.com/2.33/chromedriver_win32.zip",
-      "checksum": "718df64a6e2b2efde50b26ac22fde229"
+      "url": "https://chromedriver.storage.googleapis.com/2.42/chromedriver_win32.zip",
+      "checksum": "28d91b31311146250e7ef1afbcd6d026"
     },
     "linux": {
-      "url": "https://chromedriver.storage.googleapis.com/2.33/chromedriver_linux64.zip",
-      "checksum": "6dc329fb8ecdff6a9f74eea053434662"
+      "url": "https://chromedriver.storage.googleapis.com/2.42/chromedriver_linux64.zip",
+      "checksum": "acfcc29fb03df9e913ef4c360a121ad1"
     },
     "mac": {
-      "url": "https://chromedriver.storage.googleapis.com/2.33/chromedriver_mac64.zip",
-      "checksum": "3d520b8ede8e9deb8c9a2efe2aec5f35"
+      "url": "https://chromedriver.storage.googleapis.com/2.42/chromedriver_mac64.zip",
+      "checksum": "3fc0e4a97cbf2c8c2a9b824d95e25351"
     }
   },
   {


### PR DESCRIPTION
Updated DriverFactoryHelper to support "HTTPS" via configurable parameter "SELENIUM_PROTOCOL".

I ran into an issue while trying to connect to a remote device cloud which only supports "HTTPS". Therefore I added a new capability "SELENIUM_PROTOCOL" to change the protocol from "HTTP" to "HTTPS" if needed. Standard for this capability is set to "HTTP". 

- [X ] By placing an `X` in the preceding checkbox, I verify that I am a PayPal employee or
I have signed the [Contributor License Agreement](https://github.com/paypal/SeLion#contributing)

---
